### PR TITLE
core/kazoo_number_manager: add 'attributes' phone number feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ _*
 *.so
 *.swp
 *.swo
+*.pid
+*~
 ebin
 erl_crash.dump
 log
+.tool-versions
+deps
+make
+/TAGS
+.deps.mk

--- a/applications/crossbar/doc/phone_numbers.md
+++ b/applications/crossbar/doc/phone_numbers.md
@@ -22,6 +22,11 @@ Schema for a number
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`attributes.class` | An arbitrary class label for the phone number, e.g. 'clean', 'sanitization_period', 'premium', etc. | `string()` |   | `false` |  
+`attributes.enabled` | Enables/disables the attributes number feature | `boolean()` |   | `false` |  
+`attributes.group` | An arbitrary group name for the phone number | `string()` |   | `false` |  
+`attributes.traffic` | The traffic type that this number carries, e.g. 'fax', 'short_calls', 'conference', etc. | `string()` |   | `false` |  
+`attributes` | Number feature that allows some attributes/options/labels to be specified on a number. | `object()` |   | `false` |  
 `carrier_name` |   | `string(1..30)` |   | `false` |  
 `cnam.display_name` |   | `string(1..15)` |   | `false` |  
 `cnam.inbound_lookup` |   | `boolean()` |   | `false` |  
@@ -1643,3 +1648,20 @@ curl -v -X POST \
     "status": "success"
 }
 ```
+
+## Number Attributes Feature
+
+> POST /v2/accounts/{ACCOUNT_ID}/phone_numbers/{PHONE_NUMBER}
+
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data":{"id":"{NUMBER}", "used_by":"callflow", "attributes":{"enabled":true, "group":"cust_support", "class":"clean", "traffic":"fax"}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/phone_numbers/{PHONE_NUMBER}
+```
+
+The attributes feature can be used for setting some labels on a number, so that it can be treated differently than the default by internal or external systems. The `group` and `class` parameters are arbitrary, the `options` parameter is a list of arbitrary strings, and the `traffic` parameter is used for different processing when this number is used as source or destination. When `traffic` is set to `fax`, calls to/from the number passing through Trunkstore will force media processing, add the `fax` flag to the call (if outbound), and enable T.38 variables.
+
+Also, two config parameters are available, which will enable similar fax call handling for Callflows (outbound A-leg) and Kazoo Endpoint (inbound B-leg) (overriding the `media.fax_option` setting):
+- `system_config.callflows.number_attributes_lookup`
+- `system_config.kazoo_endpoint.number_attributes_lookup`

--- a/applications/crossbar/doc/ref/phone_numbers.md
+++ b/applications/crossbar/doc/ref/phone_numbers.md
@@ -10,6 +10,11 @@ Schema for a number
 
 Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
+`attributes.class` | An arbitrary class label for the phone number, e.g. 'clean', 'sanitization_period', 'premium', etc. | `string()` |   | `false` |  
+`attributes.enabled` | Enables/disables the attributes number feature | `boolean()` |   | `false` |  
+`attributes.group` | An arbitrary group name for the phone number | `string()` |   | `false` |  
+`attributes.traffic` | The traffic type that this number carries, e.g. 'fax', 'short_calls', 'conference', etc. | `string()` |   | `false` |  
+`attributes` | Number feature that allows some attributes/options/labels to be specified on a number. | `object()` |   | `false` |  
 `carrier_name` |   | `string(1..30)` |   | `false` |  
 `cnam.display_name` |   | `string(1..15)` |   | `false` |  
 `cnam.inbound_lookup` |   | `boolean()` |   | `false` |  
@@ -283,3 +288,20 @@ curl -v -X POST \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/phone_numbers/fix/{PHONE_NUMBER}
 ```
 
+
+## Number Attributes Feature
+
+> POST /v2/accounts/{ACCOUNT_ID}/phone_numbers/{PHONE_NUMBER}
+
+```shell
+curl -v -X POST \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    -d '{"data":{"id":"{NUMBER}", "used_by":"callflow", "attributes":{"enabled":true, "group":"cust_support", "class":"clean", "traffic":"fax"}}}' \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/phone_numbers/{PHONE_NUMBER}
+```
+
+The attributes feature can be used for setting some labels on a number, so that it can be treated differently than the default by internal or external systems. The `group` and `class` parameters are arbitrary, the `options` parameter is a list of arbitrary strings, and the `traffic` parameter is used for different processing when this number is used as source or destination. When `traffic` is set to `fax`, calls to/from the number passing through Trunkstore will force media processing, add the `fax` flag to the call (if outbound), and enable T.38 variables.
+
+Also, two config parameters are available, which will enable similar fax call handling for Callflows (outbound A-leg) and Kazoo Endpoint (inbound B-leg) (overriding the `media.fax_option` setting):
+- `system_config.callflows.number_attributes_lookup`
+- `system_config.kazoo_endpoint.number_attributes_lookup`

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -26776,6 +26776,28 @@
         "phone_numbers": {
             "description": "Schema for a number",
             "properties": {
+                "attributes": {
+                    "description": "Number feature that allows some attributes/options/labels to be specified on a number.",
+                    "properties": {
+                        "class": {
+                            "description": "An arbitrary class label for the phone number, e.g. 'clean', 'sanitization_period', 'premium', etc.",
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "description": "Enables/disables the attributes number feature",
+                            "type": "boolean"
+                        },
+                        "group": {
+                            "description": "An arbitrary group name for the phone number",
+                            "type": "string"
+                        },
+                        "traffic": {
+                            "description": "The traffic type that this number carries, e.g. 'fax', 'short_calls', 'conference', etc.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
                 "carrier_name": {
                     "maxLength": 30,
                     "minLength": 1,

--- a/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
+++ b/applications/crossbar/priv/couchdb/schemas/phone_numbers.json
@@ -3,6 +3,28 @@
     "_id": "phone_numbers",
     "description": "Schema for a number",
     "properties": {
+        "attributes": {
+            "description": "Number feature that allows some attributes/options/labels to be specified on a number.",
+            "properties": {
+                "class": {
+                    "description": "An arbitrary class label for the phone number, e.g. 'clean', 'sanitization_period', 'premium', etc.",
+                    "type": "string"
+                },
+                "enabled": {
+                    "description": "Enables/disables the attributes number feature",
+                    "type": "boolean"
+                },
+                "group": {
+                    "description": "An arbitrary group name for the phone number",
+                    "type": "string"
+                },
+                "traffic": {
+                    "description": "The traffic type that this number carries, e.g. 'fax', 'short_calls', 'conference', etc.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "carrier_name": {
             "maxLength": 30,
             "minLength": 1,

--- a/core/kazoo_documents/src/kzd_phone_numbers.erl
+++ b/core/kazoo_documents/src/kzd_phone_numbers.erl
@@ -1,11 +1,16 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
-%%% @doc
+%%% @copyright (C) 2010-2025, 2600Hz
+%%% @doc Accessors for `phone_numbers' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_phone_numbers).
 
 -export([new/0]).
+-export([attributes/1, attributes/2, set_attributes/2]).
+-export([attributes_class/1, attributes_class/2, set_attributes_class/2]).
+-export([attributes_enabled/1, attributes_enabled/2, set_attributes_enabled/2]).
+-export([attributes_group/1, attributes_group/2, set_attributes_group/2]).
+-export([attributes_traffic/1, attributes_traffic/2, set_attributes_traffic/2]).
 -export([carrier_name/1, carrier_name/2, set_carrier_name/2]).
 -export([cnam/1, cnam/2, set_cnam/2]).
 -export([cnam_display_name/1, cnam_display_name/2, set_cnam_display_name/2]).
@@ -56,6 +61,66 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec attributes(doc()) -> kz_term:api_object().
+attributes(Doc) ->
+    attributes(Doc, 'undefined').
+
+-spec attributes(doc(), Default) -> kz_json:object() | Default.
+attributes(Doc, Default) ->
+    kz_json:get_json_value([<<"attributes">>], Doc, Default).
+
+-spec set_attributes(doc(), kz_json:object()) -> doc().
+set_attributes(Doc, Attributes) ->
+    kz_json:set_value([<<"attributes">>], Attributes, Doc).
+
+-spec attributes_class(doc()) -> kz_term:api_binary().
+attributes_class(Doc) ->
+    attributes_class(Doc, 'undefined').
+
+-spec attributes_class(doc(), Default) -> binary() | Default.
+attributes_class(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"class">>], Doc, Default).
+
+-spec set_attributes_class(doc(), binary()) -> doc().
+set_attributes_class(Doc, AttributesClass) ->
+    kz_json:set_value([<<"attributes">>, <<"class">>], AttributesClass, Doc).
+
+-spec attributes_enabled(doc()) -> kz_term:api_boolean().
+attributes_enabled(Doc) ->
+    attributes_enabled(Doc, 'undefined').
+
+-spec attributes_enabled(doc(), Default) -> boolean() | Default.
+attributes_enabled(Doc, Default) ->
+    kz_json:get_boolean_value([<<"attributes">>, <<"enabled">>], Doc, Default).
+
+-spec set_attributes_enabled(doc(), boolean()) -> doc().
+set_attributes_enabled(Doc, AttributesEnabled) ->
+    kz_json:set_value([<<"attributes">>, <<"enabled">>], AttributesEnabled, Doc).
+
+-spec attributes_group(doc()) -> kz_term:api_binary().
+attributes_group(Doc) ->
+    attributes_group(Doc, 'undefined').
+
+-spec attributes_group(doc(), Default) -> binary() | Default.
+attributes_group(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"group">>], Doc, Default).
+
+-spec set_attributes_group(doc(), binary()) -> doc().
+set_attributes_group(Doc, AttributesGroup) ->
+    kz_json:set_value([<<"attributes">>, <<"group">>], AttributesGroup, Doc).
+
+-spec attributes_traffic(doc()) -> kz_term:api_binary().
+attributes_traffic(Doc) ->
+    attributes_traffic(Doc, 'undefined').
+
+-spec attributes_traffic(doc(), Default) -> binary() | Default.
+attributes_traffic(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"traffic">>], Doc, Default).
+
+-spec set_attributes_traffic(doc(), binary()) -> doc().
+set_attributes_traffic(Doc, AttributesTraffic) ->
+    kz_json:set_value([<<"attributes">>, <<"traffic">>], AttributesTraffic, Doc).
 
 -spec carrier_name(doc()) -> kz_term:api_ne_binary().
 carrier_name(Doc) ->

--- a/core/kazoo_documents/src/kzd_phone_numbers.erl.src
+++ b/core/kazoo_documents/src/kzd_phone_numbers.erl.src
@@ -1,11 +1,16 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
+%%% @copyright (C) 2010-2025, 2600Hz
 %%% @doc Accessors for `phone_numbers' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_phone_numbers).
 
 -export([new/0]).
+-export([attributes/1, attributes/2, set_attributes/2]).
+-export([attributes_class/1, attributes_class/2, set_attributes_class/2]).
+-export([attributes_enabled/1, attributes_enabled/2, set_attributes_enabled/2]).
+-export([attributes_group/1, attributes_group/2, set_attributes_group/2]).
+-export([attributes_traffic/1, attributes_traffic/2, set_attributes_traffic/2]).
 -export([carrier_name/1, carrier_name/2, set_carrier_name/2]).
 -export([cnam/1, cnam/2, set_cnam/2]).
 -export([cnam_display_name/1, cnam_display_name/2, set_cnam_display_name/2]).
@@ -56,6 +61,66 @@
 -spec new() -> doc().
 new() ->
     kz_json_schema:default_object(?SCHEMA).
+
+-spec attributes(doc()) -> kz_term:api_object().
+attributes(Doc) ->
+    attributes(Doc, 'undefined').
+
+-spec attributes(doc(), Default) -> kz_json:object() | Default.
+attributes(Doc, Default) ->
+    kz_json:get_json_value([<<"attributes">>], Doc, Default).
+
+-spec set_attributes(doc(), kz_json:object()) -> doc().
+set_attributes(Doc, Attributes) ->
+    kz_json:set_value([<<"attributes">>], Attributes, Doc).
+
+-spec attributes_class(doc()) -> kz_term:api_binary().
+attributes_class(Doc) ->
+    attributes_class(Doc, 'undefined').
+
+-spec attributes_class(doc(), Default) -> binary() | Default.
+attributes_class(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"class">>], Doc, Default).
+
+-spec set_attributes_class(doc(), binary()) -> doc().
+set_attributes_class(Doc, AttributesClass) ->
+    kz_json:set_value([<<"attributes">>, <<"class">>], AttributesClass, Doc).
+
+-spec attributes_enabled(doc()) -> kz_term:api_boolean().
+attributes_enabled(Doc) ->
+    attributes_enabled(Doc, 'undefined').
+
+-spec attributes_enabled(doc(), Default) -> boolean() | Default.
+attributes_enabled(Doc, Default) ->
+    kz_json:get_boolean_value([<<"attributes">>, <<"enabled">>], Doc, Default).
+
+-spec set_attributes_enabled(doc(), boolean()) -> doc().
+set_attributes_enabled(Doc, AttributesEnabled) ->
+    kz_json:set_value([<<"attributes">>, <<"enabled">>], AttributesEnabled, Doc).
+
+-spec attributes_group(doc()) -> kz_term:api_binary().
+attributes_group(Doc) ->
+    attributes_group(Doc, 'undefined').
+
+-spec attributes_group(doc(), Default) -> binary() | Default.
+attributes_group(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"group">>], Doc, Default).
+
+-spec set_attributes_group(doc(), binary()) -> doc().
+set_attributes_group(Doc, AttributesGroup) ->
+    kz_json:set_value([<<"attributes">>, <<"group">>], AttributesGroup, Doc).
+
+-spec attributes_traffic(doc()) -> kz_term:api_binary().
+attributes_traffic(Doc) ->
+    attributes_traffic(Doc, 'undefined').
+
+-spec attributes_traffic(doc(), Default) -> binary() | Default.
+attributes_traffic(Doc, Default) ->
+    kz_json:get_binary_value([<<"attributes">>, <<"traffic">>], Doc, Default).
+
+-spec set_attributes_traffic(doc(), binary()) -> doc().
+set_attributes_traffic(Doc, AttributesTraffic) ->
+    kz_json:set_value([<<"attributes">>, <<"traffic">>], AttributesTraffic, Doc).
 
 -spec carrier_name(doc()) -> kz_term:api_ne_binary().
 carrier_name(Doc) ->

--- a/core/kazoo_number_manager/include/knm_phone_number.hrl
+++ b/core/kazoo_number_manager/include/knm_phone_number.hrl
@@ -82,7 +82,9 @@
 -define(FEATURE_RINGBACK, <<"ringback">>).
 -define(FEATURE_SMS, <<"sms">>).
 -define(FEATURE_MMS, <<"mms">>).
+-define(FEATURE_ATTRIBUTES, <<"attributes">>).
 
+-define(PROVIDER_ATTRIBUTES, <<"knm_", (?FEATURE_ATTRIBUTES)/binary>>).
 -define(PROVIDER_RENAME_CARRIER, <<"knm_rename_carrier">>).
 -define(PROVIDER_FORCE_OUTBOUND, <<"knm_", (?FEATURE_FORCE_OUTBOUND)/binary>>).
 
@@ -90,7 +92,8 @@
 -define(LEGACY_TELNYX_E911, <<"telnyx_e911">>).
 -define(LEGACY_VITELITY_E911, <<"vitelity_e911">>).
 
--define(KAZOO_NUMBER_FEATURES, [?FEATURE_FAILOVER
+-define(KAZOO_NUMBER_FEATURES, [?FEATURE_ATTRIBUTES
+                               ,?FEATURE_FAILOVER
                                ,?FEATURE_FORCE_OUTBOUND
                                ,?FEATURE_PREPEND
                                ,?FEATURE_RINGBACK
@@ -111,7 +114,8 @@
 -define(ALL_KNM_FEATURES, ?KAZOO_NUMBER_FEATURES ++ ?EXTERNAL_NUMBER_FEATURES ++ ?ADMIN_ONLY_FEATURES).
 
 %% Keys on number document's root reserved to update features
--define(FEATURES_ROOT_KEYS, [?FEATURE_CNAM
+-define(FEATURES_ROOT_KEYS, [?FEATURE_ATTRIBUTES
+                            ,?FEATURE_CNAM
                             ,?FEATURE_E911
                             ,?FEATURE_FAILOVER
                             ,?FEATURE_FORCE_OUTBOUND
@@ -134,6 +138,11 @@
 -define(E911_STREET1, <<"street_address">>).
 -define(E911_STREET2, <<"extended_address">>).
 -define(E911_ZIP, <<"postal_code">>).
+
+-define(ATTRIBUTES_GROUP, <<"group">>).
+-define(ATTRIBUTES_CLASS, <<"class">>).
+-define(ATTRIBUTES_OPTIONS, <<"options">>).
+-define(ATTRIBUTES_TRAFFIC, <<"traffic">>).
 
 -define(PREPEND_ENABLED, <<"enabled">>).
 -define(PREPEND_NAME, <<"name">>).

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -1,8 +1,9 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2015-2022, 2600Hz
+%%% @copyright (C) 2015-2025, 2600Hz
 %%% @doc
 %%% @author Peter Defebvre
 %%% @author Pierre Fenoll
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(knm_phone_number).
@@ -69,6 +70,14 @@
 -export_type([callback/0
              ,callbacks/0
              ]).
+
+-export([number_attribute/2
+        ,number_group/1
+        ,number_class/1
+        ,number_traffic/1
+        ,is_fax_number/1
+        ,number_attribute_options/1
+        ]).
 
 -ifdef(TEST).
 -export([set_is_dirty/2]).
@@ -1618,10 +1627,16 @@ private_to_public() ->
     RingbackPub = [[?FEATURE_RINGBACK, ?RINGBACK_EARLY]
                   ,[?FEATURE_RINGBACK, ?RINGBACK_TRANSFER]
                   ],
+    AttributesPub = [[?FEATURE_ATTRIBUTES, ?FEATURE_ENABLED]
+                    ,[?FEATURE_ATTRIBUTES, ?ATTRIBUTES_GROUP]
+                    ,[?FEATURE_ATTRIBUTES, ?ATTRIBUTES_CLASS]
+                    ,[?FEATURE_ATTRIBUTES, ?ATTRIBUTES_TRAFFIC]
+                    ],
     #{?FEATURE_E911 => E911Pub
      ,?LEGACY_VITELITY_E911 => E911Pub
      ,?LEGACY_DASH_E911 => E911Pub
      ,?LEGACY_TELNYX_E911 => E911Pub
+     ,?FEATURE_ATTRIBUTES => AttributesPub
      ,?FEATURE_CNAM => CNAMPub
      ,?FEATURE_CNAM_INBOUND => CNAMPub
      ,?FEATURE_CNAM_OUTBOUND => CNAMPub
@@ -1698,6 +1713,47 @@ is_reserved_from_parent(#knm_phone_number{assigned_to = ?MATCH_ACCOUNT_RAW(Assig
         andalso ?LOG_DEBUG("is reserved from parent, allowing"),
     Authorized;
 is_reserved_from_parent(_) -> 'false'.
+
+%%------------------------------------------------------------------------------
+%% @doc Number attributes feature functions
+%% @end
+%%------------------------------------------------------------------------------
+-spec number_attribute(kz_term:ne_binary() | knm_phone_number(), kz_term:ne_binary()) -> kz_term:api_ne_binary() | kz_json:object() | kz_term:api_ne_binaries().
+number_attribute(DID, Attribute) when is_binary(DID) ->
+    case fetch(DID) of
+        {'ok', Number} -> number_attribute(Number, Attribute);
+        _Err -> lager:debug("failed to fetch number ~s: ~p", [DID, _Err])
+    end;
+number_attribute(Number, Attribute) ->
+    case feature(Number, ?FEATURE_ATTRIBUTES) of
+        'undefined' -> 'undefined';
+        Feature -> kz_json:get_value(Attribute, Feature)
+    end.
+
+-spec number_group(kz_term:ne_binary() | knm_phone_number()) -> kz_term:api_ne_binary().
+number_group(Number) ->
+    number_attribute(Number, ?ATTRIBUTES_GROUP).
+
+-spec number_class(kz_term:ne_binary() | knm_phone_number()) -> kz_term:api_ne_binary().
+number_class(Number) ->
+    number_attribute(Number, ?ATTRIBUTES_CLASS).
+
+-spec number_attribute_options(kz_term:ne_binary() | knm_phone_number()) -> kz_term:ne_binaries().
+number_attribute_options(Number) ->
+    OptsList = number_attribute(Number, ?ATTRIBUTES_OPTIONS),
+    case OptsList of %% only non-empty binaries are returned
+        [_|_] ->
+            lists:filter(fun(X) -> is_binary(X) andalso X =/= <<>> end, OptsList);
+        _ -> []
+    end.
+
+-spec number_traffic(kz_term:ne_binary() | knm_phone_number()) -> kz_term:api_ne_binary().
+number_traffic(Number) ->
+    number_attribute(Number, ?ATTRIBUTES_TRAFFIC).
+
+-spec is_fax_number(kz_term:ne_binary() | knm_phone_number()) -> boolean().
+is_fax_number(Number) ->
+    number_traffic(Number) =:= <<"fax">>.
 
 %%%=============================================================================
 %%% Internal functions

--- a/core/kazoo_number_manager/src/providers/knm_attributes.erl
+++ b/core/kazoo_number_manager/src/providers/knm_attributes.erl
@@ -1,0 +1,85 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025, RuhNet
+%%% @doc Handle the Number Attributes feature
+%%% This Attributes feature can be used for setting some labels on a number, so
+%%% that it can be treated differently than the default by internal or external
+%%% systems/apps. The `group` and `class` parameters are arbitrary, the `options`
+%%% parameter is a list of arbitrary strings, and the `traffic` parameter is
+%%% used for different processing when this number is used as source or
+%%% destination. When `traffic` is set to `fax`, calls to/from the number
+%%% passing through Trunkstore will force media processing, add the `fax` flag
+%%% to the call (if outbound), and enable T.38 variables.
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(knm_attributes).
+-behaviour(knm_gen_provider).
+
+-export([save/1]).
+-export([delete/1]).
+
+-include("knm.hrl").
+
+-define(KEY, ?FEATURE_ATTRIBUTES).
+
+%%------------------------------------------------------------------------------
+%% @doc This function is called each time a number is saved, and will
+%% update the attributes (if the number is in service).
+%% @end
+%%------------------------------------------------------------------------------
+-spec save(knm_number:knm_number()) -> knm_number:knm_number().
+save(Number) ->
+    NumberState = knm_phone_number:state(knm_number:phone_number(Number)),
+    save(Number, NumberState).
+
+-spec save(knm_number:knm_number(), kz_term:ne_binary()) -> knm_number:knm_number().
+save(Number, ?NUMBER_STATE_IN_SERVICE) ->
+    update_attributes(Number);
+save(Number, _State) ->
+    delete(Number).
+
+%%------------------------------------------------------------------------------
+%% @doc This function is called each time a number is deleted, and will
+%% remove the number attributes.
+%% @end
+%%------------------------------------------------------------------------------
+-spec delete(knm_number:knm_number()) -> knm_number:knm_number().
+delete(Number) ->
+    case feature(Number) of
+        'undefined' -> Number;
+        _Else -> knm_providers:deactivate_feature(Number, ?KEY)
+    end.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc
+%% @end
+%%------------------------------------------------------------------------------
+-spec feature(knm_number:knm_number()) -> kz_json:api_json_term().
+feature(Number) ->
+    knm_phone_number:feature(knm_number:phone_number(Number), ?KEY).
+
+%%------------------------------------------------------------------------------
+%% @doc Update attributes feature on the number
+%% @end
+%%------------------------------------------------------------------------------
+-spec update_attributes(knm_number:knm_number()) -> knm_number:knm_number().
+update_attributes(Number) ->
+    CurrentAttributes = feature(Number),
+    PhoneNumber = knm_number:phone_number(Number),
+    AttributesFromDoc = kz_json:get_ne_json_value(?KEY, knm_phone_number:doc(PhoneNumber)),
+    NotChanged = kz_json:are_equal(AttributesFromDoc, CurrentAttributes),
+    case kz_term:is_empty(AttributesFromDoc) of
+        'true' ->
+            knm_providers:deactivate_feature(Number, ?KEY);
+        'false' when NotChanged ->
+            Number;
+        'false' ->
+            case kz_json:is_true(?FEATURE_ENABLED, AttributesFromDoc) of
+                'false' -> knm_providers:deactivate_feature(Number, ?KEY);
+                'true' -> knm_providers:activate_feature(Number, {?KEY, AttributesFromDoc})
+            end
+    end.

--- a/core/kazoo_number_manager/src/providers/knm_providers.erl
+++ b/core/kazoo_number_manager/src/providers/knm_providers.erl
@@ -1,9 +1,10 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2016-2022, 2600Hz
-%%% @doc Handle prepend feature
+%%% @copyright (C) 2016-2025, 2600Hz
+%%% @doc
 %%% @author Peter Defebvre
 %%% @author Pierre Fenoll
 %%% @author Karl Anderson
+%%% @author Ruel Tmeizeh
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(knm_providers).
@@ -494,6 +495,8 @@ provider_module(?FEATURE_RENAME_CARRIER, _) ->
     ?PROVIDER_RENAME_CARRIER;
 provider_module(?FEATURE_FORCE_OUTBOUND, _) ->
     ?PROVIDER_FORCE_OUTBOUND;
+provider_module(?FEATURE_ATTRIBUTES, _) ->
+    ?PROVIDER_ATTRIBUTES;
 provider_module(Other, _) ->
     ?LOG_DEV("unmatched feature provider ~p, allowing", [Other]),
     Other.


### PR DESCRIPTION
Allows specification of `group`, `class`, and `traffic` type for phone numbers. The `group` and `class` parameters are arbitrary labels that can be used in future for internal or external apps; the `traffic` parameter will initially be used for setting T.38 fax variables on fax calls when it is set to value of 'fax'.

Also, minor additions to .gitignore file. 
