### PR TITLE
applications/notify: add additional maintenance funcs and set default system from email

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -33597,6 +33597,10 @@
                     "description": "notify should_persist_for_retry",
                     "type": "boolean"
                 },
+                "system_default_from_email": {
+                    "description": "notify system_default_from_email",
+                    "type": "string"
+                },
                 "use_federated_listener": {
                     "default": false,
                     "description": "notify use federated listener",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.notify.json
@@ -94,6 +94,10 @@
             "description": "notify should_persist_for_retry",
             "type": "boolean"
         },
+        "system_default_from_email": {
+            "description": "notify system_default_from_email",
+            "type": "string"
+        },
         "use_federated_listener": {
             "default": false,
             "description": "notify use federated listener",

--- a/applications/notify/doc/README.md
+++ b/applications/notify/doc/README.md
@@ -20,7 +20,12 @@ sup notify_maintenance configure_smtp_username username
 sup notify_maintenance configure_smtp_password password
 sup notify_maintenance configure_smtp_auth always
 sup notify_maintenance configure_smtp_port 123
+sup notify_maintenance configure_smtp_tls always # STARTTLS (commonly used on submission port 587)
+sup notify_maintenance configure_smtp_ssl false  # SSL Connection (commonly used on SMTPS port 465 instead of STARTTLS)
+
+sup notify_maintenance system_default_from_email no_reply@example.com
 ```
+If `system_config/notify.system_default_from_email` isn't set, then an auto-generated `no_reply@{fqdn_hostname_of_server}` will be used when there is no override of the from address at template or notification category level.
 
 ### Couch document
 Update your the smtp_client document via couch manually. Should look like this.
@@ -33,6 +38,7 @@ Example:
        "username": "username",
        "password": "password",
        "auth": "always",
+       "tls": "if_available",
        "port": "587",
    },
    "pvt_account_id": "system_config",

--- a/applications/notify/src/notify_maintenance.erl
+++ b/applications/notify/src/notify_maintenance.erl
@@ -93,7 +93,12 @@ configure_smtp_password(Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec configure_smtp_auth(kz_term:ne_binary()) -> 'ok' | 'failed'.
-configure_smtp_auth(Value) ->
+configure_smtp_auth(<<"always">>) -> config_smtp_auth(<<"always">>);
+configure_smtp_auth(<<"never">>) -> config_smtp_auth(<<"never">>);
+configure_smtp_auth(<<"if_available">>) -> config_smtp_auth(<<"if_available">>).
+
+-spec config_smtp_auth(kz_term:ne_binary()) -> 'ok' | 'failed'.
+config_smtp_auth(Value) ->
     {'ok', _} = update_smtp_client_document(<<"auth">>, Value),
     'ok'.
 
@@ -102,8 +107,8 @@ configure_smtp_auth(Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec configure_smtp_port(kz_term:ne_binary()) -> 'ok' | 'failed'.
-configure_smtp_port(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"port">>, Value),
+configure_smtp_port(PortNumber) ->
+    {'ok', _} = update_smtp_client_document(<<"port">>, PortNumber),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -111,8 +116,8 @@ configure_smtp_port(Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec configure_smtp_ssl(kz_term:ne_binary()) -> 'ok' | 'failed'.
-configure_smtp_ssl(Value) ->
-    {'ok', _} = update_smtp_client_document(<<"use_ssl">>, kz_term:to_boolean(Value)),
+configure_smtp_ssl(Boolean) ->
+    {'ok', _} = update_smtp_client_document(<<"use_ssl">>, kz_term:to_boolean(Boolean)),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -120,7 +125,12 @@ configure_smtp_ssl(Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec configure_smtp_tls(kz_term:ne_binary()) -> 'ok' | 'failed'.
-configure_smtp_tls(Value) ->
+configure_smtp_tls(<<"always">>) -> config_smtp_tls(<<"always">>);
+configure_smtp_tls(<<"if_available">>) -> config_smtp_tls(<<"if_available">>);
+configure_smtp_tls(<<"never">>) -> config_smtp_tls(<<"never">>).
+
+-spec config_smtp_tls(kz_term:ne_binary()) -> 'ok' | 'failed'.
+config_smtp_tls(Value) ->
     TLS = case Value of
               <<"true">> -> <<"always">>;
               <<"always">> -> <<"always">>;
@@ -144,8 +154,8 @@ configure_smtp_tls(Value) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec system_default_from_email(kz_term:ne_binary()) -> 'ok' | 'failed'.
-system_default_from_email(Value) ->
-    {'ok', _} = kapps_config:set(?NOTIFY_CONFIG_CAT, <<"system_default_from_email">>, Value),
+system_default_from_email(EmailAddress) ->
+    {'ok', _} = kapps_config:set(?NOTIFY_CONFIG_CAT, <<"system_default_from_email">>, EmailAddress),
     'ok'.
 
 %%------------------------------------------------------------------------------

--- a/applications/notify/src/notify_maintenance.erl
+++ b/applications/notify/src/notify_maintenance.erl
@@ -1,8 +1,9 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2012-2022, 2600Hz
+%%% @copyright (C) 2012-2025, 2600Hz
 %%% @doc
 %%% @author Karl Anderson
 %%% @author Michael Dunton
+%%% @author Ruel Tmeizeh www.ruhnet.co
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(notify_maintenance).
@@ -19,7 +20,10 @@
         ,configure_smtp_password/1
         ,configure_smtp_auth/1
         ,configure_smtp_port/1
+        ,configure_smtp_ssl/1
+        ,configure_smtp_tls/1
         ]).
+-export([system_default_from_email/1]).
 
 -define(TEMPLATE_PATH, code:priv_dir(?APP)).
 -define(SYSTEM_CONFIG_DB, <<"system_config">>).
@@ -100,6 +104,48 @@ configure_smtp_auth(Value) ->
 -spec configure_smtp_port(kz_term:ne_binary()) -> 'ok' | 'failed'.
 configure_smtp_port(Value) ->
     {'ok', _} = update_smtp_client_document(<<"port">>, Value),
+    'ok'.
+
+%%------------------------------------------------------------------------------
+%% @doc Configures the ssl option---whether or not to use SSL connection
+%% @end
+%%------------------------------------------------------------------------------
+-spec configure_smtp_ssl(kz_term:ne_binary()) -> 'ok' | 'failed'.
+configure_smtp_ssl(Value) ->
+    {'ok', _} = update_smtp_client_document(<<"use_ssl">>, kz_term:to_boolean(Value)),
+    'ok'.
+
+%%------------------------------------------------------------------------------
+%% @doc Configures the tls option (STARTTLS).
+%% @end
+%%------------------------------------------------------------------------------
+-spec configure_smtp_tls(kz_term:ne_binary()) -> 'ok' | 'failed'.
+configure_smtp_tls(Value) ->
+    TLS = case Value of
+              <<"true">> -> <<"always">>;
+              <<"always">> -> <<"always">>;
+              <<"false">> -> <<"never">>;
+              <<"never">> -> <<"never">>;
+              <<"if_available">> -> <<"if_available">>;
+              _ -> 'invalid'
+          end,
+    case TLS of
+        'invalid' ->
+            io:format("valid options are one of: [always, if_available, never]~n"),
+            'failed';
+        _ ->
+            {'ok', _} = update_smtp_client_document(<<"tls">>, TLS),
+            'ok'
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Configures the system wide default from email---used when there is no
+%% more specific email specified on particular notify modules or on the request.
+%% @end
+%%------------------------------------------------------------------------------
+-spec system_default_from_email(kz_term:ne_binary()) -> 'ok' | 'failed'.
+system_default_from_email(Value) ->
+    {'ok', _} = kapps_config:set(?NOTIFY_CONFIG_CAT, <<"system_default_from_email">>, Value),
     'ok'.
 
 %%------------------------------------------------------------------------------
@@ -337,6 +383,6 @@ open_system_config(Id) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec update_smtp_client_document(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kz_json:object()}.
+-spec update_smtp_client_document(kz_term:ne_binary(), kz_term:ne_binary() | boolean()) -> {'ok', kz_json:object()}.
 update_smtp_client_document(Key, Value) ->
     kapps_config:set(?SMTP_CLIENT_DOC, Key, Value).

--- a/applications/notify/src/notify_util.erl
+++ b/applications/notify/src/notify_util.erl
@@ -262,8 +262,9 @@ get_service_props(Request, Account, ConfigCat) ->
     DefaultEmail = kz_json:get_ne_value(<<"support_email">>, Request
                                        ,kapps_config:get_ne_binary(ConfigCat, <<"default_support_email">>, <<"support@2600hz.com">>)),
     UnconfiguredFrom = list_to_binary([<<"no_reply@">>, kz_term:to_binary(net_adm:localhost())]),
+    SystemWideFrom = kapps_config:get_ne_binary(?NOTIFY_CONFIG_CAT, <<"system_default_from_email">>, UnconfiguredFrom),
     DefaultFrom = kz_json:get_ne_value(<<"send_from">>, Request
-                                      ,kapps_config:get_ne_binary(ConfigCat, <<"default_from">>, UnconfiguredFrom)),
+                                      ,kapps_config:get_ne_binary(ConfigCat, <<"default_from">>, SystemWideFrom)),
     DefaultCharset = kz_json:get_ne_value(<<"template_charset">>, Request
                                          ,kapps_config:get_binary(ConfigCat, <<"default_template_charset">>, <<>>)),
     JObj = find_notification_settings(binary:split(ConfigCat, <<".">>), kzd_accounts:tree(Account)),

--- a/applications/teletype/src/teletype_util.erl
+++ b/applications/teletype/src/teletype_util.erl
@@ -1,7 +1,8 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2014-2022, 2600Hz
+%%% @copyright (C) 2014-2025, 2600Hz
 %%% @doc
 %%% @author James Aimonetti
+%%% @author Ruel Tmeizeh www.ruhnet.co
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(teletype_util).
@@ -457,7 +458,8 @@ maybe_add_parent_params(AccountId, AccountJObj) ->
 
 -spec default_from_address() -> kz_term:ne_binary().
 default_from_address() ->
-    list_to_binary([<<"no_reply@">>, net_adm:localhost()]).
+    UnconfiguredFrom = list_to_binary([<<"no_reply@">>, net_adm:localhost()]),
+    kapps_config:get_ne_binary(?NOTIFY_CONFIG_CAT, <<"system_default_from_email">>, UnconfiguredFrom).
 
 -spec default_reply_to() -> kz_term:api_ne_binary().
 default_reply_to() -> 'undefined'.


### PR DESCRIPTION
notify_maintenance work

- configure_smtp_ssl - sets full TLS/SSL mode (boolean)
- configure_smtp_tls - sets STARTTLS to always/if_available/never
- system_default_from_email - sets a system-wide default "from"
- improved notify_maintenance code for sup bash completion

Notify and Teletype will use the system-wide from email when there is no more specific from email set for a template or notify config category.