### PR TITLE
applications/crossbar: add simplified CDRs output, with account local time in RFC3339 format

### DIFF
--- a/applications/crossbar/doc/cdrs.md
+++ b/applications/crossbar/doc/cdrs.md
@@ -110,6 +110,15 @@ curl -v -X GET \
     http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/cdrs?created_from={FROM_TIMESTAMP}&created_to={TO_TIMESTAMP}&utc_offset={SECONDS_OFFSET}
 ```
 
+Get CDRs in simplified format, with timestamp in local time (for the account) in RFC3339 format:
+
+```shell
+curl -v -X GET \
+    -H "X-Auth-Token: {AUTH_TOKEN}" \
+    http://{SERVER}:8000/v2/accounts/{ACCOUNT_ID}/cdrs?created_from={FROM_TIMESTAMP}&created_to={TO_TIMESTAMP}&simple=true
+```
+
+
 Get CDRs as CSV:
 
 ```shell

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -568,7 +568,7 @@ col_unix_timestamp(_JObj, Timestamp, _Context) -> kz_term:to_binary(kz_time:greg
 col_rfc1036(_JObj, Timestamp, _Context) -> kz_time:rfc1036(Timestamp).
 col_iso8601(_JObj, Timestamp, _Context) -> kz_date:to_iso8601_extended(Timestamp).
 col_iso8601_combined(_JObj, Timestamp, _Context) -> kz_time:iso8601(Timestamp).
-col_rfc3339_local(JObj, Timestamp, _Context) -> local_rfc3339_time(JObj, Timestamp).
+col_rfc3339_local(JObj, Timestamp, _Context) -> rfc3339_local_time(JObj, Timestamp).
 col_account_call_type(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"account_billing">>], JObj, <<>>).
 col_rate(JObj, _Timestamp, _Context) -> kz_term:to_binary(kz_currency:units_to_dollars(kz_json:get_value([?KEY_CCV, <<"rate">>], JObj, 0))).
 col_rate_name(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"rate_name">>], JObj, <<>>).
@@ -618,38 +618,14 @@ user_ext(UserDoc) ->
     case Ext of
         'undefined' -> Name;
         <<>> -> Name;
+        Name -> Name;
         Exten -> <<Name/binary, " - ", Exten/binary>>
     end.
 
--spec local_rfc3339_time(kz_json:object(), kz_time:gregorian_second()) -> kz_term:ne_binary().
-local_rfc3339_time(JObj, Timestamp) ->
+-spec rfc3339_local_time(kz_json:object(), kz_time:gregorian_second()) -> kz_term:ne_binary().
+rfc3339_local_time(JObj, Timestamp) ->
     AccountId = kz_json:get_ne_binary_value([?KEY_CCV, <<"account_id">>], JObj),
-    Timezone = kzd_accounts:timezone(AccountId),
-    UTCDateTime = calendar:gregorian_seconds_to_datetime(Timestamp),
-    Offset = local_tz_offset(UTCDateTime, Timezone), %% -0400
-    LocalDateTime = localtime:utc_to_local(UTCDateTime, kz_term:to_list(Timezone)), %% {{2025,11,2},{1,17,34}}
-    {{Y, M, D}, {H, Min, S}} = LocalDateTime,
-    YYYY = kz_term:to_binary(Y),
-    MM = kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>),
-    DD = kz_binary:pad_left(kz_term:to_binary(D), 2, <<"0">>),
-    HH = kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>),
-    MMin = kz_binary:pad_left(kz_term:to_binary(Min), 2, <<"0">>),
-    SS = kz_binary:pad_left(kz_term:to_binary(S), 2, <<"0">>),
-    %% 2025-11-02T01:41:17-04:00
-    <<YYYY/binary, "-", MM/binary, "-", DD/binary, "T", HH/binary, ":", MMin/binary, ":", SS/binary, Offset/binary>>.
-
--spec local_tz_offset(calendar:datetime(), kz_term:ne_binary()) -> kz_term:ne_binary().
-local_tz_offset(Datetime, <<FromTz/binary>>) ->
-    case localtime:tz_shift(Datetime, "UTC", kz_term:to_list(FromTz)) of %% offset of the Timezone relative to UTC
-        0 -> <<"+0000">>;
-        {'error', 'unknown_tz'} -> <<"+00:00">>;
-        {Sign, H, M} ->
-            list_to_binary([kz_term:to_binary(Sign)
-                           ,kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>)
-                           ,":"
-                           ,kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>)
-                           ])
-    end.
+    kz_time:rfc3339_local(Timestamp, AccountId).
 
 -spec interaction_path(cb_context:context()) -> 'account' | 'user' | 'undefined'.
 interaction_path(Context) ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -1,14 +1,14 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2025, 2600Hz
 %%% @doc CDR
 %%% Read only access to CDR docs
-%%%
 %%%
 %%% @author Edouard Swiac
 %%% @author James Aimonetti
 %%% @author Karl Anderson
 %%% @author Ben Wann
 %%% @author Sponsored by GTNetwork LLC, Implemented by SIPLABS LLC
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cb_cdrs).
@@ -48,6 +48,7 @@
 -define(PATH_LEGS, <<"legs">>).
 -define(PATH_SUMMARY, <<"summary">>).
 
+-define(KEY_SIMPLE, <<"simple">>).
 -define(KEY_UTC_OFFSET, <<"utc_offset">>).
 -define(KEY_CCV, <<"custom_channel_vars">>).
 
@@ -79,6 +80,7 @@
         ,{<<"rfc_1036">>, fun col_rfc1036/3}
         ,{<<"iso_8601">>, fun col_iso8601/3}
         ,{<<"iso_8601_combined">>, fun col_iso8601_combined/3}
+        ,{<<"rfc3339_local">>, fun col_rfc3339_local/3}
         ,{<<"call_type">>, fun col_account_call_type/3}
         ,{<<"rate">>, fun col_rate/3}
         ,{<<"rate_name">>, fun col_rate_name/3}
@@ -94,6 +96,20 @@
        ,[{<<"reseller_cost">>, fun col_reseller_cost/3}
         ,{<<"reseller_call_type">>, fun col_reseller_call_type/3}
         ]).
+
+-define(COLUMNS_SIMPLE
+       ,[{<<"timestamp">>, fun col_rfc3339_local/3}
+        ,{<<"caller_id_number">>, fun col_caller_id_number/3}
+        ,{<<"caller_id_name">>, fun col_caller_id_name/3}
+        ,{<<"callee_id_number">>, fun col_callee_id_number/3}
+        ,{<<"callee_id_name">>, fun col_callee_id_name/3}
+        ,{<<"duration_seconds">>, fun col_duration_seconds/3}
+        ,{<<"direction">>, fun col_call_direction/3}
+        ,{<<"hangup_cause">>, fun col_hangup_cause/3}
+        ,{<<"disposition">>, fun col_disposition/3}
+        ,{<<"user">>, fun col_user_ext/3}
+        ]).
+
 
 -define(CONTEXT_COLUMNS
        ,[{<<"inception_direction">>, fun col_inception_direction/3}]
@@ -484,6 +500,13 @@ maybe_add_csv_header(Context, <<"csv">>, [Head | Tail]=Data) ->
 
 -spec csv_rows(cb_context:context()) -> [{kz_term:ne_binary(), cdr_column_fun()}].
 csv_rows(Context) ->
+    case kz_term:is_true(cb_context:req_value(Context, ?KEY_SIMPLE)) of %% check for simple output mode
+        'true' -> ?COLUMNS_SIMPLE;
+        _ -> csv_rows(Context, 'false')
+    end.
+
+-spec csv_rows(cb_context:context(), atom()) -> [{kz_term:ne_binary(), cdr_column_fun()}].
+csv_rows(Context, 'false') -> %% not simple output mode
     case cb_context:fetch(Context, 'is_reseller', 'false') of
         'false' -> ?COLUMNS;
         'true' -> ?COLUMNS ++ ?COLUMNS_RESELLER
@@ -491,7 +514,10 @@ csv_rows(Context) ->
 
 -spec json_rows(cb_context:context()) -> [{kz_term:ne_binary(), cdr_column_fun()}].
 json_rows(Context) ->
-    json_rows(Context, interaction_path(Context)).
+    case kz_term:is_true(cb_context:req_value(Context, ?KEY_SIMPLE)) of %% check for simple output mode
+        'true' -> ?COLUMNS_SIMPLE;
+        _ -> json_rows(Context, interaction_path(Context))
+    end.
 
 -spec json_rows(cb_context:context(), atom()) -> [{kz_term:ne_binary(), cdr_column_fun()}].
 json_rows(Context, 'undefined') ->
@@ -542,6 +568,7 @@ col_unix_timestamp(_JObj, Timestamp, _Context) -> kz_term:to_binary(kz_time:greg
 col_rfc1036(_JObj, Timestamp, _Context) -> kz_time:rfc1036(Timestamp).
 col_iso8601(_JObj, Timestamp, _Context) -> kz_date:to_iso8601_extended(Timestamp).
 col_iso8601_combined(_JObj, Timestamp, _Context) -> kz_time:iso8601(Timestamp).
+col_rfc3339_local(JObj, Timestamp, _Context) -> local_rfc3339_time(JObj, Timestamp).
 col_account_call_type(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"account_billing">>], JObj, <<>>).
 col_rate(JObj, _Timestamp, _Context) -> kz_term:to_binary(kz_currency:units_to_dollars(kz_json:get_value([?KEY_CCV, <<"rate">>], JObj, 0))).
 col_rate_name(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"rate_name">>], JObj, <<>>).
@@ -568,6 +595,60 @@ col_inception_direction(JObj, _Timestamp, Context) ->
                 <<"inbound">> -> <<"origination">>;
                 <<"outbound">> -> <<"termination">>
             end
+    end.
+
+col_user_ext(JObj, _Timestamp, _Context) ->
+    AccountId = kz_json:get_ne_binary_value([?KEY_CCV, <<"account_id">>], JObj),
+    OwnerId = kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj),
+    user_ext(AccountId, OwnerId).
+
+-spec user_ext(kz_term:api_binary(), kz_term:api_binary()) -> binary().
+user_ext(_, 'undefined') -> <<>>;
+user_ext(_, <<>>) -> <<>>;
+user_ext(AccountId, OwnerId) ->
+    case kzd_users:fetch(AccountId, OwnerId) of
+        {'ok', UserDoc} -> user_ext(UserDoc);
+        _ -> <<>>
+    end.
+
+-spec user_ext(kz_json:object()) -> binary().
+user_ext(UserDoc) ->
+    Name = kzd_user:name(UserDoc),
+    Ext = kzd_users:presence_id(UserDoc),
+    case Ext of
+        'undefined' -> Name;
+        <<>> -> Name;
+        Exten -> <<Name/binary, " - ", Exten/binary>>
+    end.
+
+-spec local_rfc3339_time(kz_json:object(), kz_time:gregorian_second()) -> kz_term:ne_binary().
+local_rfc3339_time(JObj, Timestamp) ->
+    AccountId = kz_json:get_ne_binary_value([?KEY_CCV, <<"account_id">>], JObj),
+    Timezone = kzd_accounts:timezone(AccountId),
+    UTCDateTime = calendar:gregorian_seconds_to_datetime(Timestamp),
+    Offset = local_tz_offset(UTCDateTime, Timezone), %% -0400
+    LocalDateTime = localtime:utc_to_local(UTCDateTime, kz_term:to_list(Timezone)), %% {{2025,11,2},{1,17,34}}
+    {{Y, M, D}, {H, Min, S}} = LocalDateTime,
+    YYYY = kz_term:to_binary(Y),
+    MM = kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>),
+    DD = kz_binary:pad_left(kz_term:to_binary(D), 2, <<"0">>),
+    HH = kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>),
+    MMin = kz_binary:pad_left(kz_term:to_binary(Min), 2, <<"0">>),
+    SS = kz_binary:pad_left(kz_term:to_binary(S), 2, <<"0">>),
+    %% 2025-11-02T01:41:17-04:00
+    <<YYYY/binary, "-", MM/binary, "-", DD/binary, "T", HH/binary, ":", MMin/binary, ":", SS/binary, Offset/binary>>.
+
+-spec local_tz_offset(calendar:datetime(), kz_term:ne_binary()) -> kz_term:ne_binary().
+local_tz_offset(Datetime, <<FromTz/binary>>) ->
+    case localtime:tz_shift(Datetime, "UTC", kz_term:to_list(FromTz)) of %% offset of the Timezone relative to UTC
+        0 -> <<"+0000">>;
+        {'error', 'unknown_tz'} -> <<"+00:00">>;
+        {Sign, H, M} ->
+            list_to_binary([kz_term:to_binary(Sign)
+                           ,kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>)
+                           ,":"
+                           ,kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>)
+                           ])
     end.
 
 -spec interaction_path(cb_context:context()) -> 'account' | 'user' | 'undefined'.

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -12,6 +12,7 @@
         ,pretty_print_datetime/1, pretty_print_datetime/2
         ,rfc1036/1, rfc1036/2
         ,rfc2822/1, rfc2822/2
+        ,rfc3339_local/2
         ,iso8601/1, iso8601/2
         ,iso8601_time/1
         ,from_iso8601/1
@@ -45,6 +46,7 @@
 -compile({'no_auto_import', [now/0]}).
 
 -include_lib("kazoo_stdlib/include/kz_types.hrl").
+-include_lib("kazoo_stdlib/include/kazoo_json.hrl").
 
 -type now() :: erlang:timestamp().
 %% {MegaSecs :: integer() >= 0, Secs :: integer() >= 0, MicroSecs :: integer() >= 0}
@@ -189,8 +191,55 @@ tz_offset(Datetime, <<FromTz/binary>>) ->
             list_to_binary([kz_term:to_binary(Sign)
                            ,kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>)
                            ,kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>)
-                           ])
+                           ]);
+        _Else -> <<"+0000">>
     end.
+
+-spec rfc3339_local_tz_offset(calendar:datetime(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
+rfc3339_local_tz_offset(Datetime, ToTz) ->
+    case localtime:tz_shift(Datetime, "UTC", kz_term:to_list(ToTz)) of %% offset of the Timezone relative to UTC
+        0 -> <<"+0000">>;
+        {'error', 'unknown_tz'} -> <<"Z">>;
+        {Sign, H, M} ->
+            list_to_binary([kz_term:to_binary(Sign)
+                           ,kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>)
+                           ,":"
+                           ,kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>)
+                           ]);
+        _Else -> <<"Z">>
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Format UTC datetime or Gregorian timestamp as an RFC3339 timestamp with
+%% local time offset from a timezone. Input is assumed to be in UTC. Timezone
+%% can be directly specified as a binary or derived from the Account ID, or
+%% from an Account, User, or Device JSON object.
+%% NOTE that when inputting a user or device object, inheritance will not be
+%% taken into account, and only the explicit timezone value (if any) will be
+%% used.
+%% @end
+%%------------------------------------------------------------------------------
+-spec rfc3339_local(calendar:datetime() | gregorian_seconds(), kz_term:api_ne_binary() | kz_json:object()) -> kz_term:ne_binary().
+rfc3339_local(Timestamp, ?JSON_WRAPPER(_)=JObj) -> %% JObj could be an account, user, or device
+    Timezone = kz_json:get_binary_value([<<"timezone">>], JObj),
+    rfc3339_local(Timestamp, Timezone);
+rfc3339_local(Timestamp, <<AccountId:32/binary>>) ->
+    Timezone = kzd_accounts:timezone(AccountId),
+    rfc3339_local(Timestamp, Timezone);
+rfc3339_local(Timestamp, Timezone) when is_integer(Timestamp) ->
+    rfc3339_local(calendar:gregorian_seconds_to_datetime(Timestamp), Timezone);
+rfc3339_local(UTCDateTime={{_,_,_},{_,_,_}}, Timezone) ->
+    LocalDateTime = localtime:utc_to_local(UTCDateTime, kz_term:to_list(Timezone)), %% {{2025,11,2},{1,17,34}}
+    {{Y, M, D}, {H, Min, S}} = LocalDateTime,
+    YYYY = kz_term:to_binary(Y),
+    MM = kz_binary:pad_left(kz_term:to_binary(M), 2, <<"0">>),
+    DD = kz_binary:pad_left(kz_term:to_binary(D), 2, <<"0">>),
+    HH = kz_binary:pad_left(kz_term:to_binary(H), 2, <<"0">>),
+    MMin = kz_binary:pad_left(kz_term:to_binary(Min), 2, <<"0">>),
+    SS = kz_binary:pad_left(kz_term:to_binary(S), 2, <<"0">>),
+    Offset = rfc3339_local_tz_offset(UTCDateTime, Timezone), %% -0400
+    %% 2025-11-02T01:41:17-04:00
+    <<YYYY/binary, "-", MM/binary, "-", DD/binary, "T", HH/binary, ":", MMin/binary, ":", SS/binary, Offset/binary>>.
 
 %%------------------------------------------------------------------------------
 %% @doc Format time part of ISO 8601.

--- a/core/kazoo_stdlib/src/kz_time.erl
+++ b/core/kazoo_stdlib/src/kz_time.erl
@@ -198,7 +198,7 @@ tz_offset(Datetime, <<FromTz/binary>>) ->
 -spec rfc3339_local_tz_offset(calendar:datetime(), kz_term:api_ne_binary()) -> kz_term:ne_binary().
 rfc3339_local_tz_offset(Datetime, ToTz) ->
     case localtime:tz_shift(Datetime, "UTC", kz_term:to_list(ToTz)) of %% offset of the Timezone relative to UTC
-        0 -> <<"+0000">>;
+        0 -> <<"+00:00">>;
         {'error', 'unknown_tz'} -> <<"Z">>;
         {Sign, H, M} ->
             list_to_binary([kz_term:to_binary(Sign)


### PR DESCRIPTION
This PR adds a simplified CDRs output, with fewer columns, and with the timestamp in the account's local time (in a standard RFC3339 format).
