### PR TITLE
core/kazoo_endpoint: caller ID improvements in kz_endpoint and callflow

### DIFF
--- a/applications/callflow/src/cf_route_win.erl
+++ b/applications/callflow/src/cf_route_win.erl
@@ -268,10 +268,18 @@ update_ccvs(Call) ->
               ),
 
     CCVs = kapps_call:custom_channel_vars(Call),
+    Username = kz_json:get_binary_value(<<"Username">>, CCVs),
+    %% check original CID name to make sure it is not the SIP username (which is default if endpoint doesn't specify it):
+    OriginalCIDName = case kz_json:get_binary_value(<<"Original-Caller-ID-Name">>, CCVs) of
+                          Username -> CIDName;
+                          _Name -> _Name
+                      end,
     Props = props:filter_undefined(
               [{<<"Hold-Media">>, kz_attributes:moh_attributes(<<"media_id">>, Call)}
               ,{<<"Caller-ID-Name">>, CIDName}
               ,{<<"Caller-ID-Number">>, CIDNumber}
+              ,{<<"Original-Caller-ID-Name">>, OriginalCIDName}
+              ,{<<"Original-Caller-ID-Number">>, kapps_call:caller_id_number(Call)}
                | get_incoming_security(Call)
                ++ kz_privacy:flags(CCVs)
               ]),

--- a/applications/callflow/src/module/cf_resources.erl
+++ b/applications/callflow/src/module/cf_resources.erl
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc Callflow resource.
 %%%
 %%% <h4>Data options:</h4>
@@ -55,6 +55,7 @@
 %%%
 %%% @author Karl Anderson
 %%% @author Sponsored by Raffel Internet B.V. Implemented by Voyager Internet Ltd.
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cf_resources).
@@ -279,6 +280,23 @@ get_caller_id(Data, Call) ->
     Type = kz_json:get_value(<<"caller_id_type">>, Data, <<"external">>),
     kz_attributes:caller_id(Type, Call).
 
+%%------------------------------------------------------------------------------
+%% @doc get_asserted_identity/2 will check several things and return a tuple
+%% with asserted number/name/realm (any of which may be undefined).
+%% If the system_config/callflow.resources.default_asserted_identity_privacy
+%% is true and number privacy is enabled (either permanently or from a user
+%% dialing *67) then asserted identity will be used for CLI. (This is required
+%% for anonymous calls in Australia and potentially elsewhere.) If this call is
+%% not private, then the caller_id object will be checked for the passthrough
+%% setting, and if it's enabled (AND allowed from system_config), the asserted
+%% identity will be set from the CLI that the endpoint originally sent.
+%% Otherwise, system_config/callflow.resources.default_asserted_identity will
+%% be checked to determine whether or not to set asserted identity from the
+%% external CLI.
+%% If none of these conditions are matched, asserted identity will be undefined,
+%% meaning that no P-Asserted-Identity header will be used on this call.
+%% @end
+%%------------------------------------------------------------------------------
 -spec get_asserted_identity(kz_json:object(), kapps_call:call()) ->
           {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
 get_asserted_identity(_Data, Call) ->
@@ -286,9 +304,32 @@ get_asserted_identity(_Data, Call) ->
         {'error', _E} ->
             {'undefined', 'undefined', 'undefined'};
         {'ok', Endpoint} ->
-            CallerId = kzd_devices:caller_id(Endpoint),
-            {DefaultNumber, DefaultName, DefaultRealm} =
-                maybe_default_asserted_identity(Endpoint, Call),
+            PrivacyFlags = get_privacy_flags(Call),
+            AssertedFun =
+                case kapps_config:get_is_true(?RES_CONFIG_CAT, <<"default_asserted_identity_privacy">>, 'false')
+                    andalso props:get_is_true(?KEY_PRIVACY_HIDE_NUMBER, PrivacyFlags, 'false')
+                of
+                    'true' -> fun fallback_asserted_identity/2; %% returns asserted identity
+                    'false' -> fun maybe_default_asserted_identity/2 %% might return undefined
+                end,
+            maybe_asserted_identity(Endpoint, Call, AssertedFun) %% might return undefined
+    end.
+
+-spec maybe_asserted_identity(kz_endpoint:endpoint(), kapps_call:call(), fun()) ->
+          {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
+maybe_asserted_identity(Endpoint, Call, AssertedFun) ->
+    CallerId = kzd_devices:caller_id(Endpoint),
+    case kzd_caller_id:asserted_passthrough(CallerId, 'false')
+        andalso kapps_config:get_is_true(<<"kazoo_endpoint">>, <<"allow_passthrough_caller_id">>, 'true')
+    of
+        'true' ->
+            CCVs = kapps_call:custom_channel_vars(Call),
+            {kz_json:get_binary_value(<<"Original-Caller-ID-Number">>, CCVs)
+            ,kz_json:get_binary_value(<<"Original-Caller-ID-Name">>, CCVs)
+            ,kapps_call:account_realm(Call)
+            };
+        'false' ->
+            {DefaultNumber, DefaultName, DefaultRealm} = AssertedFun(Endpoint, Call),
             {kzd_caller_id:asserted_number(CallerId, DefaultNumber)
             ,kzd_caller_id:asserted_name(CallerId, DefaultName)
             ,kzd_caller_id:asserted_realm(CallerId, DefaultRealm)
@@ -298,15 +339,21 @@ get_asserted_identity(_Data, Call) ->
 -spec maybe_default_asserted_identity(kz_endpoint:endpoint(), kapps_call:call()) ->
           {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
 maybe_default_asserted_identity(Endpoint, Call) ->
-    CallerId = kzd_devices:caller_id(Endpoint),
     case kapps_config:get_is_true(?RES_CONFIG_CAT, <<"default_asserted_identity">>, 'false') of
         'false' -> {'undefined', 'undefined', 'undefined'};
-        'true' ->
-            {kzd_caller_id:external_number(CallerId)
-            ,get_asserted_default_name(CallerId, Call)
-            ,kapps_call:account_realm(Call)
-            }
+        'true' -> fallback_asserted_identity(Endpoint, Call)
     end.
+
+%% gets number/name/realm from caller_id.external and account, since we need to use
+%% asserted identity, but it is not specified.
+-spec fallback_asserted_identity(kz_endpoint:endpoint(), kapps_call:call()) ->
+          {kz_term:api_binary(), kz_term:api_binary(), kz_term:api_binary()}.
+fallback_asserted_identity(Endpoint, Call) ->
+    CallerId = kzd_devices:caller_id(Endpoint),
+    {kzd_caller_id:external_number(CallerId)
+    ,get_asserted_default_name(CallerId, Call)
+    ,kapps_call:account_realm(Call)
+    }.
 
 -spec get_asserted_default_name(kz_json:object(), kapps_call:call()) -> kz_term:api_binary().
 get_asserted_default_name(CallerId, Call) ->

--- a/applications/crossbar/doc/accounts.md
+++ b/applications/crossbar/doc/accounts.md
@@ -26,7 +26,11 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` | Parameters for server-side call waiting | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_options.ensure_valid` | Ensure caller id is valid (must match a DID on the account) | `boolean()` |   | `false` |  
+`caller_id_options.ensure_valid_owner` | Ensure caller id is valid (must match a DID assigned to the user) | `boolean()` |   | `false` |  
 `caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.passthrough_ensure_valid` | Ensure passthrough caller id is valid (must match a DID on the account) | `boolean()` |   | `false` |  
+`caller_id_options.passthrough_ensure_valid_owner` | Ensure passthrough caller id is valid (must match a DID assigned to the user) | `boolean()` |   | `false` |  
 `caller_id_options.show_rate` | Whether to show the rate | `boolean()` |   | `false` |  
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
@@ -117,16 +121,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### dialplans

--- a/applications/crossbar/doc/devices.md
+++ b/applications/crossbar/doc/devices.md
@@ -139,16 +139,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### custom_sip_headers

--- a/applications/crossbar/doc/ref/accounts.md
+++ b/applications/crossbar/doc/ref/accounts.md
@@ -18,7 +18,11 @@ Key | Description | Type | Default | Required | Support Level
 `call_restriction` | Account level call restrictions for each available number classification | `object()` | `{}` | `false` |  
 `call_waiting` | Parameters for server-side call waiting | [#/definitions/call_waiting](#call_waiting) |   | `false` |  
 `caller_id` | The account default caller ID parameters | [#/definitions/caller_id](#caller_id) |   | `false` |  
+`caller_id_options.ensure_valid` | Ensure caller id is valid (must match a DID on the account) | `boolean()` |   | `false` |  
+`caller_id_options.ensure_valid_owner` | Ensure caller id is valid (must match a DID assigned to the user) | `boolean()` |   | `false` |  
 `caller_id_options.outbound_privacy` | Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing | `string('full' | 'name' | 'number' | 'none')` |   | `false` |  
+`caller_id_options.passthrough_ensure_valid` | Ensure passthrough caller id is valid (must match a DID on the account) | `boolean()` |   | `false` |  
+`caller_id_options.passthrough_ensure_valid_owner` | Ensure passthrough caller id is valid (must match a DID assigned to the user) | `boolean()` |   | `false` |  
 `caller_id_options.show_rate` | Whether to show the rate | `boolean()` |   | `false` |  
 `caller_id_options` | custom properties for configuring caller_id | `object()` |   | `false` |  
 `dial_plan` | A list of default rules used to modify dialed numbers | [#/definitions/dialplans](#dialplans) |   | `false` |  
@@ -109,16 +113,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### dialplans

--- a/applications/crossbar/doc/ref/devices.md
+++ b/applications/crossbar/doc/ref/devices.md
@@ -136,16 +136,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### custom_sip_headers

--- a/applications/crossbar/doc/ref/users.md
+++ b/applications/crossbar/doc/ref/users.md
@@ -120,16 +120,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### dialplans

--- a/applications/crossbar/doc/users.md
+++ b/applications/crossbar/doc/users.md
@@ -122,16 +122,20 @@ Key | Description | Type | Default | Required | Support Level
 --- | ----------- | ---- | ------- | -------- | -------------
 `asserted.name` | The asserted identity name for the object type | `string(0..35)` |   | `false` |  
 `asserted.number` | The asserted identity number for the object type | `string(0..35)` |   | `false` |  
+`asserted.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `asserted.realm` | The asserted identity realm for the object type | `string()` |   | `false` |  
 `asserted` | Used to convey the proven identity of the originator of a request within a trusted network. | `object()` |   | `false` |  
 `emergency.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `emergency.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`emergency.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `emergency` | The caller ID used when a resource is flagged as 'emergency' | `object()` |   | `false` |  
 `external.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `external.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`external.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `external` | The default caller ID used when dialing external numbers | `object()` |   | `false` |  
 `internal.name` | The caller id name for the object type | `string(0..35)` |   | `false` |  
 `internal.number` | The caller id number for the object type | `string(0..35)` |   | `false` |  
+`internal.passthrough` | Whether to pass through CLI from the endpoint | `boolean()` |   | `false` |  
 `internal` | The default caller ID used when dialing internal extensions | `object()` |   | `false` |  
 
 ### dialplans

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -492,6 +492,14 @@
                 "caller_id_options": {
                     "description": "custom properties for configuring caller_id",
                     "properties": {
+                        "ensure_valid": {
+                            "description": "Ensure caller id is valid (must match a DID on the account)",
+                            "type": "boolean"
+                        },
+                        "ensure_valid_owner": {
+                            "description": "Ensure caller id is valid (must match a DID assigned to the user)",
+                            "type": "boolean"
+                        },
                         "outbound_privacy": {
                             "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
                             "enum": [
@@ -501,6 +509,14 @@
                                 "none"
                             ],
                             "type": "string"
+                        },
+                        "passthrough_ensure_valid": {
+                            "description": "Ensure passthrough caller id is valid (must match a DID on the account)",
+                            "type": "boolean"
+                        },
+                        "passthrough_ensure_valid_owner": {
+                            "description": "Ensure passthrough caller id is valid (must match a DID assigned to the user)",
+                            "type": "boolean"
                         },
                         "show_rate": {
                             "description": "Whether to show the rate",
@@ -1288,6 +1304,10 @@
                             "maxLength": 35,
                             "type": "string"
                         },
+                        "passthrough": {
+                            "description": "Whether to pass through CLI from the endpoint",
+                            "type": "boolean"
+                        },
                         "realm": {
                             "description": "The asserted identity realm for the object type",
                             "type": "string"
@@ -1307,6 +1327,10 @@
                             "description": "The caller id number for the object type",
                             "maxLength": 35,
                             "type": "string"
+                        },
+                        "passthrough": {
+                            "description": "Whether to pass through CLI from the endpoint",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
@@ -1323,6 +1347,10 @@
                             "description": "The caller id number for the object type",
                             "maxLength": 35,
                             "type": "string"
+                        },
+                        "passthrough": {
+                            "description": "Whether to pass through CLI from the endpoint",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
@@ -1339,6 +1367,10 @@
                             "description": "The caller id number for the object type",
                             "maxLength": 35,
                             "type": "string"
+                        },
+                        "passthrough": {
+                            "description": "Whether to pass through CLI from the endpoint",
+                            "type": "boolean"
                         }
                     },
                     "type": "object"
@@ -29900,7 +29932,22 @@
                 },
                 "ensure_valid_caller_id": {
                     "default": false,
-                    "description": "callflow ensure valid caller id",
+                    "description": "Ensure caller id is valid (must match a DID on the account)",
+                    "type": "boolean"
+                },
+                "ensure_valid_caller_id_owner": {
+                    "default": false,
+                    "description": "Ensure caller id is valid (must match a DID assigned to the user)",
+                    "type": "boolean"
+                },
+                "ensure_valid_passthrough_caller_id": {
+                    "default": false,
+                    "description": "Ensure passthrough caller id is valid (must match a DID on the account)",
+                    "type": "boolean"
+                },
+                "ensure_valid_passthrough_caller_id_owner": {
+                    "default": false,
+                    "description": "Ensure passthrough caller id is valid (must match a DID assigned to the user)",
                     "type": "boolean"
                 },
                 "fax_detect_duration_s": {
@@ -30216,6 +30263,11 @@
                 "default_asserted_identity": {
                     "default": false,
                     "description": "When set to true, the asserted identity will have defaults and force the use of P-Asserted-Identity (instead of RPID) on all outbound offnet calls.  When set to false, P-Asserted-Identity is only used if explicitly set in the account/user/device hierarchy.",
+                    "type": "boolean"
+                },
+                "default_asserted_identity_privacy": {
+                    "default": false,
+                    "description": "When set to true, the P-Asserted-Identity header will be used (instead of RPID) on outbound offnet calls that have privacy to hide the number enabled. This is required with some carriers for anonymous calls.",
                     "type": "boolean"
                 },
                 "default_emit_account_id": {
@@ -32879,6 +32931,11 @@
         "system_config.kazoo_endpoint": {
             "description": "Schema for kazoo_endpoint system_config",
             "properties": {
+                "allow_passthrough_caller_id": {
+                    "default": true,
+                    "description": "allow endpoints to passthrough caller id when enabled on the caller id object[s]",
+                    "type": "boolean"
+                },
                 "custom_sip_interface": {
                     "description": "kazoo_endpoint custom sip interface",
                     "type": "string"

--- a/applications/crossbar/priv/couchdb/schemas/accounts.json
+++ b/applications/crossbar/priv/couchdb/schemas/accounts.json
@@ -52,6 +52,14 @@
         "caller_id_options": {
             "description": "custom properties for configuring caller_id",
             "properties": {
+                "ensure_valid": {
+                    "description": "Ensure caller id is valid (must match a DID on the account)",
+                    "type": "boolean"
+                },
+                "ensure_valid_owner": {
+                    "description": "Ensure caller id is valid (must match a DID assigned to the user)",
+                    "type": "boolean"
+                },
                 "outbound_privacy": {
                     "description": "Determines what appears as caller id for offnet outbound calls. Values: full - hides name and number; name - hides only name; number - hides only number; none - hides nothing",
                     "enum": [
@@ -61,6 +69,14 @@
                         "none"
                     ],
                     "type": "string"
+                },
+                "passthrough_ensure_valid": {
+                    "description": "Ensure passthrough caller id is valid (must match a DID on the account)",
+                    "type": "boolean"
+                },
+                "passthrough_ensure_valid_owner": {
+                    "description": "Ensure passthrough caller id is valid (must match a DID assigned to the user)",
+                    "type": "boolean"
                 },
                 "show_rate": {
                     "description": "Whether to show the rate",

--- a/applications/crossbar/priv/couchdb/schemas/caller_id.json
+++ b/applications/crossbar/priv/couchdb/schemas/caller_id.json
@@ -16,6 +16,10 @@
                     "maxLength": 35,
                     "type": "string"
                 },
+                "passthrough": {
+                    "description": "Whether to pass through CLI from the endpoint",
+                    "type": "boolean"
+                },
                 "realm": {
                     "description": "The asserted identity realm for the object type",
                     "type": "string"
@@ -35,6 +39,10 @@
                     "description": "The caller id number for the object type",
                     "maxLength": 35,
                     "type": "string"
+                },
+                "passthrough": {
+                    "description": "Whether to pass through CLI from the endpoint",
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -51,6 +59,10 @@
                     "description": "The caller id number for the object type",
                     "maxLength": 35,
                     "type": "string"
+                },
+                "passthrough": {
+                    "description": "Whether to pass through CLI from the endpoint",
+                    "type": "boolean"
                 }
             },
             "type": "object"
@@ -67,6 +79,10 @@
                     "description": "The caller id number for the object type",
                     "maxLength": 35,
                     "type": "string"
+                },
+                "passthrough": {
+                    "description": "Whether to pass through CLI from the endpoint",
+                    "type": "boolean"
                 }
             },
             "type": "object"

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.json
@@ -47,7 +47,22 @@
         },
         "ensure_valid_caller_id": {
             "default": false,
-            "description": "callflow ensure valid caller id",
+            "description": "Ensure caller id is valid (must match a DID on the account)",
+            "type": "boolean"
+        },
+        "ensure_valid_caller_id_owner": {
+            "default": false,
+            "description": "Ensure caller id is valid (must match a DID assigned to the user)",
+            "type": "boolean"
+        },
+        "ensure_valid_passthrough_caller_id": {
+            "default": false,
+            "description": "Ensure passthrough caller id is valid (must match a DID on the account)",
+            "type": "boolean"
+        },
+        "ensure_valid_passthrough_caller_id_owner": {
+            "default": false,
+            "description": "Ensure passthrough caller id is valid (must match a DID assigned to the user)",
             "type": "boolean"
         },
         "fax_detect_duration_s": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.callflow.resources.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.callflow.resources.json
@@ -8,6 +8,11 @@
             "description": "When set to true, the asserted identity will have defaults and force the use of P-Asserted-Identity (instead of RPID) on all outbound offnet calls.  When set to false, P-Asserted-Identity is only used if explicitly set in the account/user/device hierarchy.",
             "type": "boolean"
         },
+        "default_asserted_identity_privacy": {
+            "default": false,
+            "description": "When set to true, the P-Asserted-Identity header will be used (instead of RPID) on outbound offnet calls that have privacy to hide the number enabled. This is required with some carriers for anonymous calls.",
+            "type": "boolean"
+        },
         "default_emit_account_id": {
             "default": false,
             "description": "When set to true, all outbound offnet calls will include a SIP header X-Account-ID with a value of the Kazoo account UUID.",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_endpoint.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.kazoo_endpoint.json
@@ -3,6 +3,11 @@
     "_id": "system_config.kazoo_endpoint",
     "description": "Schema for kazoo_endpoint system_config",
     "properties": {
+        "allow_passthrough_caller_id": {
+            "default": true,
+            "description": "allow endpoints to passthrough caller id when enabled on the caller id object[s]",
+            "type": "boolean"
+        },
         "custom_sip_interface": {
             "description": "kazoo_endpoint custom sip interface",
             "type": "string"

--- a/core/kazoo_documents/src/kzd_accounts.erl
+++ b/core/kazoo_documents/src/kzd_accounts.erl
@@ -1,6 +1,6 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
-%%% @doc
+%%% @copyright (C) 2010-2026, 2600Hz
+%%% @doc Accessors for `accounts' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_accounts).
@@ -14,7 +14,11 @@
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
 -export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_ensure_valid/1, caller_id_options_ensure_valid/2, set_caller_id_options_ensure_valid/2]).
+-export([caller_id_options_ensure_valid_owner/1, caller_id_options_ensure_valid_owner/2, set_caller_id_options_ensure_valid_owner/2]).
 -export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
+-export([caller_id_options_passthrough_ensure_valid/1, caller_id_options_passthrough_ensure_valid/2, set_caller_id_options_passthrough_ensure_valid/2]).
+-export([caller_id_options_passthrough_ensure_valid_owner/1, caller_id_options_passthrough_ensure_valid_owner/2, set_caller_id_options_passthrough_ensure_valid_owner/2]).
 -export([caller_id_options_show_rate/1, caller_id_options_show_rate/2, set_caller_id_options_show_rate/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
@@ -237,6 +241,30 @@ caller_id_options(Doc, Default) ->
 set_caller_id_options(Doc, CallerIdOptions) ->
     kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
 
+-spec caller_id_options_ensure_valid(doc()) -> kz_term:api_boolean().
+caller_id_options_ensure_valid(Doc) ->
+    caller_id_options_ensure_valid(Doc, 'undefined').
+
+-spec caller_id_options_ensure_valid(doc(), Default) -> boolean() | Default.
+caller_id_options_ensure_valid(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"ensure_valid">>], Doc, Default).
+
+-spec set_caller_id_options_ensure_valid(doc(), boolean()) -> doc().
+set_caller_id_options_ensure_valid(Doc, CallerIdOptionsEnsureValid) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"ensure_valid">>], CallerIdOptionsEnsureValid, Doc).
+
+-spec caller_id_options_ensure_valid_owner(doc()) -> kz_term:api_boolean().
+caller_id_options_ensure_valid_owner(Doc) ->
+    caller_id_options_ensure_valid_owner(Doc, 'undefined').
+
+-spec caller_id_options_ensure_valid_owner(doc(), Default) -> boolean() | Default.
+caller_id_options_ensure_valid_owner(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"ensure_valid_owner">>], Doc, Default).
+
+-spec set_caller_id_options_ensure_valid_owner(doc(), boolean()) -> doc().
+set_caller_id_options_ensure_valid_owner(Doc, CallerIdOptionsEnsureValidOwner) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"ensure_valid_owner">>], CallerIdOptionsEnsureValidOwner, Doc).
+
 -spec caller_id_options_outbound_privacy(doc()) -> kz_term:api_binary().
 caller_id_options_outbound_privacy(Doc) ->
     caller_id_options_outbound_privacy(Doc, 'undefined').
@@ -248,6 +276,30 @@ caller_id_options_outbound_privacy(Doc, Default) ->
 -spec set_caller_id_options_outbound_privacy(doc(), binary()) -> doc().
 set_caller_id_options_outbound_privacy(Doc, CallerIdOptionsOutboundPrivacy) ->
     kz_json:set_value([<<"caller_id_options">>, <<"outbound_privacy">>], CallerIdOptionsOutboundPrivacy, Doc).
+
+-spec caller_id_options_passthrough_ensure_valid(doc()) -> kz_term:api_boolean().
+caller_id_options_passthrough_ensure_valid(Doc) ->
+    caller_id_options_passthrough_ensure_valid(Doc, 'undefined').
+
+-spec caller_id_options_passthrough_ensure_valid(doc(), Default) -> boolean() | Default.
+caller_id_options_passthrough_ensure_valid(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"passthrough_ensure_valid">>], Doc, Default).
+
+-spec set_caller_id_options_passthrough_ensure_valid(doc(), boolean()) -> doc().
+set_caller_id_options_passthrough_ensure_valid(Doc, CallerIdOptionsPassthroughEnsureValid) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"passthrough_ensure_valid">>], CallerIdOptionsPassthroughEnsureValid, Doc).
+
+-spec caller_id_options_passthrough_ensure_valid_owner(doc()) -> kz_term:api_boolean().
+caller_id_options_passthrough_ensure_valid_owner(Doc) ->
+    caller_id_options_passthrough_ensure_valid_owner(Doc, 'undefined').
+
+-spec caller_id_options_passthrough_ensure_valid_owner(doc(), Default) -> boolean() | Default.
+caller_id_options_passthrough_ensure_valid_owner(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"passthrough_ensure_valid_owner">>], Doc, Default).
+
+-spec set_caller_id_options_passthrough_ensure_valid_owner(doc(), boolean()) -> doc().
+set_caller_id_options_passthrough_ensure_valid_owner(Doc, CallerIdOptionsPassthroughEnsureValidOwner) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"passthrough_ensure_valid_owner">>], CallerIdOptionsPassthroughEnsureValidOwner, Doc).
 
 -spec caller_id_options_show_rate(doc()) -> boolean().
 caller_id_options_show_rate(Doc) ->

--- a/core/kazoo_documents/src/kzd_accounts.erl.src
+++ b/core/kazoo_documents/src/kzd_accounts.erl.src
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
+%%% @copyright (C) 2010-2026, 2600Hz
 %%% @doc Accessors for `accounts' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
@@ -14,7 +14,11 @@
 -export([call_waiting/1, call_waiting/2, set_call_waiting/2]).
 -export([caller_id/1, caller_id/2, set_caller_id/2]).
 -export([caller_id_options/1, caller_id_options/2, set_caller_id_options/2]).
+-export([caller_id_options_ensure_valid/1, caller_id_options_ensure_valid/2, set_caller_id_options_ensure_valid/2]).
+-export([caller_id_options_ensure_valid_owner/1, caller_id_options_ensure_valid_owner/2, set_caller_id_options_ensure_valid_owner/2]).
 -export([caller_id_options_outbound_privacy/1, caller_id_options_outbound_privacy/2, set_caller_id_options_outbound_privacy/2]).
+-export([caller_id_options_passthrough_ensure_valid/1, caller_id_options_passthrough_ensure_valid/2, set_caller_id_options_passthrough_ensure_valid/2]).
+-export([caller_id_options_passthrough_ensure_valid_owner/1, caller_id_options_passthrough_ensure_valid_owner/2, set_caller_id_options_passthrough_ensure_valid_owner/2]).
 -export([caller_id_options_show_rate/1, caller_id_options_show_rate/2, set_caller_id_options_show_rate/2]).
 -export([dial_plan/1, dial_plan/2, set_dial_plan/2]).
 -export([do_not_disturb/1, do_not_disturb/2, set_do_not_disturb/2]).
@@ -159,6 +163,30 @@ caller_id_options(Doc, Default) ->
 set_caller_id_options(Doc, CallerIdOptions) ->
     kz_json:set_value([<<"caller_id_options">>], CallerIdOptions, Doc).
 
+-spec caller_id_options_ensure_valid(doc()) -> kz_term:api_boolean().
+caller_id_options_ensure_valid(Doc) ->
+    caller_id_options_ensure_valid(Doc, 'undefined').
+
+-spec caller_id_options_ensure_valid(doc(), Default) -> boolean() | Default.
+caller_id_options_ensure_valid(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"ensure_valid">>], Doc, Default).
+
+-spec set_caller_id_options_ensure_valid(doc(), boolean()) -> doc().
+set_caller_id_options_ensure_valid(Doc, CallerIdOptionsEnsureValid) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"ensure_valid">>], CallerIdOptionsEnsureValid, Doc).
+
+-spec caller_id_options_ensure_valid_owner(doc()) -> kz_term:api_boolean().
+caller_id_options_ensure_valid_owner(Doc) ->
+    caller_id_options_ensure_valid_owner(Doc, 'undefined').
+
+-spec caller_id_options_ensure_valid_owner(doc(), Default) -> boolean() | Default.
+caller_id_options_ensure_valid_owner(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"ensure_valid_owner">>], Doc, Default).
+
+-spec set_caller_id_options_ensure_valid_owner(doc(), boolean()) -> doc().
+set_caller_id_options_ensure_valid_owner(Doc, CallerIdOptionsEnsureValidOwner) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"ensure_valid_owner">>], CallerIdOptionsEnsureValidOwner, Doc).
+
 -spec caller_id_options_outbound_privacy(doc()) -> kz_term:api_binary().
 caller_id_options_outbound_privacy(Doc) ->
     caller_id_options_outbound_privacy(Doc, 'undefined').
@@ -170,6 +198,30 @@ caller_id_options_outbound_privacy(Doc, Default) ->
 -spec set_caller_id_options_outbound_privacy(doc(), binary()) -> doc().
 set_caller_id_options_outbound_privacy(Doc, CallerIdOptionsOutboundPrivacy) ->
     kz_json:set_value([<<"caller_id_options">>, <<"outbound_privacy">>], CallerIdOptionsOutboundPrivacy, Doc).
+
+-spec caller_id_options_passthrough_ensure_valid(doc()) -> kz_term:api_boolean().
+caller_id_options_passthrough_ensure_valid(Doc) ->
+    caller_id_options_passthrough_ensure_valid(Doc, 'undefined').
+
+-spec caller_id_options_passthrough_ensure_valid(doc(), Default) -> boolean() | Default.
+caller_id_options_passthrough_ensure_valid(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"passthrough_ensure_valid">>], Doc, Default).
+
+-spec set_caller_id_options_passthrough_ensure_valid(doc(), boolean()) -> doc().
+set_caller_id_options_passthrough_ensure_valid(Doc, CallerIdOptionsPassthroughEnsureValid) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"passthrough_ensure_valid">>], CallerIdOptionsPassthroughEnsureValid, Doc).
+
+-spec caller_id_options_passthrough_ensure_valid_owner(doc()) -> kz_term:api_boolean().
+caller_id_options_passthrough_ensure_valid_owner(Doc) ->
+    caller_id_options_passthrough_ensure_valid_owner(Doc, 'undefined').
+
+-spec caller_id_options_passthrough_ensure_valid_owner(doc(), Default) -> boolean() | Default.
+caller_id_options_passthrough_ensure_valid_owner(Doc, Default) ->
+    kz_json:get_boolean_value([<<"caller_id_options">>, <<"passthrough_ensure_valid_owner">>], Doc, Default).
+
+-spec set_caller_id_options_passthrough_ensure_valid_owner(doc(), boolean()) -> doc().
+set_caller_id_options_passthrough_ensure_valid_owner(Doc, CallerIdOptionsPassthroughEnsureValidOwner) ->
+    kz_json:set_value([<<"caller_id_options">>, <<"passthrough_ensure_valid_owner">>], CallerIdOptionsPassthroughEnsureValidOwner, Doc).
 
 -spec caller_id_options_show_rate(doc()) -> kz_term:api_boolean().
 caller_id_options_show_rate(Doc) ->

--- a/core/kazoo_documents/src/kzd_caller_id.erl
+++ b/core/kazoo_documents/src/kzd_caller_id.erl
@@ -1,6 +1,6 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
-%%% @doc
+%%% @copyright (C) 2010-2026, 2600Hz
+%%% @doc Accessors for `caller_id' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzd_caller_id).
@@ -9,16 +9,20 @@
 -export([asserted/1, asserted/2, set_asserted/2]).
 -export([asserted_name/1, asserted_name/2, set_asserted_name/2]).
 -export([asserted_number/1, asserted_number/2, set_asserted_number/2]).
+-export([asserted_passthrough/1, asserted_passthrough/2, set_asserted_passthrough/2]).
 -export([asserted_realm/1, asserted_realm/2, set_asserted_realm/2]).
 -export([emergency/1, emergency/2, set_emergency/2]).
 -export([emergency_name/1, emergency_name/2, set_emergency_name/2]).
 -export([emergency_number/1, emergency_number/2, set_emergency_number/2]).
+-export([emergency_passthrough/1, emergency_passthrough/2, set_emergency_passthrough/2]).
 -export([external/1, external/2, set_external/2]).
 -export([external_name/1, external_name/2, set_external_name/2]).
 -export([external_number/1, external_number/2, set_external_number/2]).
+-export([external_passthrough/1, external_passthrough/2, set_external_passthrough/2]).
 -export([internal/1, internal/2, set_internal/2]).
 -export([internal_name/1, internal_name/2, set_internal_name/2]).
 -export([internal_number/1, internal_number/2, set_internal_number/2]).
+-export([internal_passthrough/1, internal_passthrough/2, set_internal_passthrough/2]).
 
 
 -include("kz_documents.hrl").
@@ -48,7 +52,7 @@ set_asserted(Doc, Asserted) ->
 asserted_name(Doc) ->
     asserted_name(Doc, 'undefined').
 
--spec asserted_name(doc(), Default) -> binary() | Default.
+-spec asserted_name(doc(), Default) -> kz_term:api_ne_binary() | Default.
 asserted_name(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"asserted">>, <<"name">>], Doc, Default).
 
@@ -60,7 +64,7 @@ set_asserted_name(Doc, AssertedName) ->
 asserted_number(Doc) ->
     asserted_number(Doc, 'undefined').
 
--spec asserted_number(doc(), Default) -> binary() | Default.
+-spec asserted_number(doc(), Default) -> kz_term:api_ne_binary() | Default.
 asserted_number(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"asserted">>, <<"number">>], Doc, Default).
 
@@ -68,11 +72,23 @@ asserted_number(Doc, Default) ->
 set_asserted_number(Doc, AssertedNumber) ->
     kz_json:set_value([<<"asserted">>, <<"number">>], AssertedNumber, Doc).
 
+-spec asserted_passthrough(doc()) -> kz_term:api_boolean().
+asserted_passthrough(Doc) ->
+    asserted_passthrough(Doc, 'undefined').
+
+-spec asserted_passthrough(doc(), Default) -> kz_term:api_boolean() | Default.
+asserted_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"asserted">>, <<"passthrough">>], Doc, Default).
+
+-spec set_asserted_passthrough(doc(), boolean()) -> doc().
+set_asserted_passthrough(Doc, AssertedPassthrough) ->
+    kz_json:set_value([<<"asserted">>, <<"passthrough">>], AssertedPassthrough, Doc).
+
 -spec asserted_realm(doc()) -> kz_term:api_binary().
 asserted_realm(Doc) ->
     asserted_realm(Doc, 'undefined').
 
--spec asserted_realm(doc(), Default) -> binary() | Default.
+-spec asserted_realm(doc(), Default) -> kz_term:api_ne_binary() | Default.
 asserted_realm(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"asserted">>, <<"realm">>], Doc, Default).
 
@@ -96,7 +112,7 @@ set_emergency(Doc, Emergency) ->
 emergency_name(Doc) ->
     emergency_name(Doc, 'undefined').
 
--spec emergency_name(doc(), Default) -> binary() | Default.
+-spec emergency_name(doc(), Default) -> kz_term:api_ne_binary() | Default.
 emergency_name(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"emergency">>, <<"name">>], Doc, Default).
 
@@ -108,13 +124,25 @@ set_emergency_name(Doc, EmergencyName) ->
 emergency_number(Doc) ->
     emergency_number(Doc, 'undefined').
 
--spec emergency_number(doc(), Default) -> binary() | Default.
+-spec emergency_number(doc(), Default) -> kz_term:api_ne_binary() | Default.
 emergency_number(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"emergency">>, <<"number">>], Doc, Default).
 
 -spec set_emergency_number(doc(), binary()) -> doc().
 set_emergency_number(Doc, EmergencyNumber) ->
     kz_json:set_value([<<"emergency">>, <<"number">>], EmergencyNumber, Doc).
+
+-spec emergency_passthrough(doc()) -> kz_term:api_boolean().
+emergency_passthrough(Doc) ->
+    emergency_passthrough(Doc, 'undefined').
+
+-spec emergency_passthrough(doc(), Default) -> kz_term:api_boolean() | Default.
+emergency_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"emergency">>, <<"passthrough">>], Doc, Default).
+
+-spec set_emergency_passthrough(doc(), boolean()) -> doc().
+set_emergency_passthrough(Doc, EmergencyPassthrough) ->
+    kz_json:set_value([<<"emergency">>, <<"passthrough">>], EmergencyPassthrough, Doc).
 
 -spec external(doc()) -> kz_term:api_object().
 external(Doc) ->
@@ -132,7 +160,7 @@ set_external(Doc, External) ->
 external_name(Doc) ->
     external_name(Doc, 'undefined').
 
--spec external_name(doc(), Default) -> binary() | Default.
+-spec external_name(doc(), Default) -> kz_term:api_ne_binary() | Default.
 external_name(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"external">>, <<"name">>], Doc, Default).
 
@@ -144,13 +172,25 @@ set_external_name(Doc, ExternalName) ->
 external_number(Doc) ->
     external_number(Doc, 'undefined').
 
--spec external_number(doc(), Default) -> binary() | Default.
+-spec external_number(doc(), Default) -> kz_term:api_ne_binary() | Default.
 external_number(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"external">>, <<"number">>], Doc, Default).
 
 -spec set_external_number(doc(), binary()) -> doc().
 set_external_number(Doc, ExternalNumber) ->
     kz_json:set_value([<<"external">>, <<"number">>], ExternalNumber, Doc).
+
+-spec external_passthrough(doc()) -> kz_term:api_boolean().
+external_passthrough(Doc) ->
+    external_passthrough(Doc, 'undefined').
+
+-spec external_passthrough(doc(), Default) -> kz_term:api_boolean() | Default.
+external_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"external">>, <<"passthrough">>], Doc, Default).
+
+-spec set_external_passthrough(doc(), boolean()) -> doc().
+set_external_passthrough(Doc, ExternalPassthrough) ->
+    kz_json:set_value([<<"external">>, <<"passthrough">>], ExternalPassthrough, Doc).
 
 -spec internal(doc()) -> kz_term:api_object().
 internal(Doc) ->
@@ -168,7 +208,7 @@ set_internal(Doc, Internal) ->
 internal_name(Doc) ->
     internal_name(Doc, 'undefined').
 
--spec internal_name(doc(), Default) -> binary() | Default.
+-spec internal_name(doc(), Default) -> kz_term:api_ne_binary() | Default.
 internal_name(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"internal">>, <<"name">>], Doc, Default).
 
@@ -180,10 +220,22 @@ set_internal_name(Doc, InternalName) ->
 internal_number(Doc) ->
     internal_number(Doc, 'undefined').
 
--spec internal_number(doc(), Default) -> binary() | Default.
+-spec internal_number(doc(), Default) -> kz_term:api_ne_binary() | Default.
 internal_number(Doc, Default) ->
     kz_json:get_ne_binary_value([<<"internal">>, <<"number">>], Doc, Default).
 
 -spec set_internal_number(doc(), binary()) -> doc().
 set_internal_number(Doc, InternalNumber) ->
     kz_json:set_value([<<"internal">>, <<"number">>], InternalNumber, Doc).
+
+-spec internal_passthrough(doc()) -> kz_term:api_boolean().
+internal_passthrough(Doc) ->
+    internal_passthrough(Doc, 'undefined').
+
+-spec internal_passthrough(doc(), Default) -> kz_term:api_boolean() | Default.
+internal_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"internal">>, <<"passthrough">>], Doc, Default).
+
+-spec set_internal_passthrough(doc(), boolean()) -> doc().
+set_internal_passthrough(Doc, InternalPassthrough) ->
+    kz_json:set_value([<<"internal">>, <<"passthrough">>], InternalPassthrough, Doc).

--- a/core/kazoo_documents/src/kzd_caller_id.erl.src
+++ b/core/kazoo_documents/src/kzd_caller_id.erl.src
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2010-2022, 2600Hz
+%%% @copyright (C) 2010-2026, 2600Hz
 %%% @doc Accessors for `caller_id' document.
 %%% @end
 %%%-----------------------------------------------------------------------------
@@ -9,16 +9,20 @@
 -export([asserted/1, asserted/2, set_asserted/2]).
 -export([asserted_name/1, asserted_name/2, set_asserted_name/2]).
 -export([asserted_number/1, asserted_number/2, set_asserted_number/2]).
+-export([asserted_passthrough/1, asserted_passthrough/2, set_asserted_passthrough/2]).
 -export([asserted_realm/1, asserted_realm/2, set_asserted_realm/2]).
 -export([emergency/1, emergency/2, set_emergency/2]).
 -export([emergency_name/1, emergency_name/2, set_emergency_name/2]).
 -export([emergency_number/1, emergency_number/2, set_emergency_number/2]).
+-export([emergency_passthrough/1, emergency_passthrough/2, set_emergency_passthrough/2]).
 -export([external/1, external/2, set_external/2]).
 -export([external_name/1, external_name/2, set_external_name/2]).
 -export([external_number/1, external_number/2, set_external_number/2]).
+-export([external_passthrough/1, external_passthrough/2, set_external_passthrough/2]).
 -export([internal/1, internal/2, set_internal/2]).
 -export([internal_name/1, internal_name/2, set_internal_name/2]).
 -export([internal_number/1, internal_number/2, set_internal_number/2]).
+-export([internal_passthrough/1, internal_passthrough/2, set_internal_passthrough/2]).
 
 
 -include("kz_documents.hrl").
@@ -68,6 +72,18 @@ asserted_number(Doc, Default) ->
 set_asserted_number(Doc, AssertedNumber) ->
     kz_json:set_value([<<"asserted">>, <<"number">>], AssertedNumber, Doc).
 
+-spec asserted_passthrough(doc()) -> kz_term:api_boolean().
+asserted_passthrough(Doc) ->
+    asserted_passthrough(Doc, 'undefined').
+
+-spec asserted_passthrough(doc(), Default) -> boolean() | Default.
+asserted_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"asserted">>, <<"passthrough">>], Doc, Default).
+
+-spec set_asserted_passthrough(doc(), boolean()) -> doc().
+set_asserted_passthrough(Doc, AssertedPassthrough) ->
+    kz_json:set_value([<<"asserted">>, <<"passthrough">>], AssertedPassthrough, Doc).
+
 -spec asserted_realm(doc()) -> kz_term:api_binary().
 asserted_realm(Doc) ->
     asserted_realm(Doc, 'undefined').
@@ -116,6 +132,18 @@ emergency_number(Doc, Default) ->
 set_emergency_number(Doc, EmergencyNumber) ->
     kz_json:set_value([<<"emergency">>, <<"number">>], EmergencyNumber, Doc).
 
+-spec emergency_passthrough(doc()) -> kz_term:api_boolean().
+emergency_passthrough(Doc) ->
+    emergency_passthrough(Doc, 'undefined').
+
+-spec emergency_passthrough(doc(), Default) -> boolean() | Default.
+emergency_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"emergency">>, <<"passthrough">>], Doc, Default).
+
+-spec set_emergency_passthrough(doc(), boolean()) -> doc().
+set_emergency_passthrough(Doc, EmergencyPassthrough) ->
+    kz_json:set_value([<<"emergency">>, <<"passthrough">>], EmergencyPassthrough, Doc).
+
 -spec external(doc()) -> kz_term:api_object().
 external(Doc) ->
     external(Doc, 'undefined').
@@ -152,6 +180,18 @@ external_number(Doc, Default) ->
 set_external_number(Doc, ExternalNumber) ->
     kz_json:set_value([<<"external">>, <<"number">>], ExternalNumber, Doc).
 
+-spec external_passthrough(doc()) -> kz_term:api_boolean().
+external_passthrough(Doc) ->
+    external_passthrough(Doc, 'undefined').
+
+-spec external_passthrough(doc(), Default) -> boolean() | Default.
+external_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"external">>, <<"passthrough">>], Doc, Default).
+
+-spec set_external_passthrough(doc(), boolean()) -> doc().
+set_external_passthrough(Doc, ExternalPassthrough) ->
+    kz_json:set_value([<<"external">>, <<"passthrough">>], ExternalPassthrough, Doc).
+
 -spec internal(doc()) -> kz_term:api_object().
 internal(Doc) ->
     internal(Doc, 'undefined').
@@ -187,3 +227,15 @@ internal_number(Doc, Default) ->
 -spec set_internal_number(doc(), binary()) -> doc().
 set_internal_number(Doc, InternalNumber) ->
     kz_json:set_value([<<"internal">>, <<"number">>], InternalNumber, Doc).
+
+-spec internal_passthrough(doc()) -> kz_term:api_boolean().
+internal_passthrough(Doc) ->
+    internal_passthrough(Doc, 'undefined').
+
+-spec internal_passthrough(doc(), Default) -> boolean() | Default.
+internal_passthrough(Doc, Default) ->
+    kz_json:get_boolean_value([<<"internal">>, <<"passthrough">>], Doc, Default).
+
+-spec set_internal_passthrough(doc(), boolean()) -> doc().
+set_internal_passthrough(Doc, InternalPassthrough) ->
+    kz_json:set_value([<<"internal">>, <<"passthrough">>], InternalPassthrough, Doc).

--- a/core/kazoo_endpoint/doc/privacy-cid.md
+++ b/core/kazoo_endpoint/doc/privacy-cid.md
@@ -8,6 +8,8 @@ Kazoo has a default Feature Code `"*67"` which can be use for making a call with
 
 The system config parameter `system_config/privacy/privacy_mode` can be use to configure which parts of Caller ID should be anonymize if privacy flags are set for a Call. This is especially is important for Outbound Calls, if your carrier is expecting known Caller IDs and they honor privacy flags when they're routing calls to third party carriers or final destination.
 
+Some carriers (or jurisdictions---Australia is one) require anonymous calls to include a P-Asserted-Identity header with a valid number. You can force a PAI header to be used all the time with the `system_config/callflow.resources/default_asserted_identity` parameter. Alternately, the `system_config/callflow.resources/default_asserted_identity_privacy` uses the PAI header only on anonymous calls (anytime number is hidden).
+
 > WARNING: allowing to pass Caller IDs as is should only applied to carriers which you *TRUST* since it will expose caller's identity.
 
 ## Configuring Privacy System wide and/or in Account level

--- a/core/kazoo_endpoint/src/kazoo_endpoint.hrl
+++ b/core/kazoo_endpoint/src/kazoo_endpoint.hrl
@@ -10,6 +10,7 @@
 -define(CONFIG_CAT, <<"kazoo_endpoint">>).
 
 -define(CACHE_NAME, 'kazoo_endpoint_cache').
+-define(CALLFLOW_CACHE_NAME, 'callflow_cache').
 
 -define(ATTR_LOWER_KEY, <<109,108,112,112>>).
 -define(ATTR_UPPER_KEY, <<109,097,120,095,112,114,101,099,101,100,101,110,099,101>>).

--- a/core/kazoo_endpoint/src/kz_attributes.erl
+++ b/core/kazoo_endpoint/src/kz_attributes.erl
@@ -1,8 +1,9 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc
 %%% @author Karl Anderson
 %%% @author James Aimonetti
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kz_attributes).
@@ -114,11 +115,35 @@ maybe_get_endpoint_cid(Validate, Attribute, Call) ->
             lager:info("unable to get endpoint: ~p", [_R]),
             maybe_normalize_cid('undefined', 'undefined', Validate, Attribute, Call);
         {'ok', JObj} ->
-            Number = get_cid_or_default(Attribute, <<"number">>, JObj),
-            Name = get_cid_or_default(Attribute, <<"name">>, JObj),
-            _ = log_configured_endpoint_cid(Attribute, Name, Number),
-            Call1 = maybe_add_originals_to_kvs(Number, Name, Call),
-            maybe_use_presence_number(Number, Name, JObj, Validate, Attribute, Call1)
+            Call1 = maybe_add_passthrough_to_kvs(Attribute, JObj, Call),
+            {Number, Name} = get_endpoint_cid(Attribute, JObj, Call1),
+            Call2 = maybe_add_originals_to_kvs(Number, Name, Call1),
+            maybe_use_presence_number(Number, Name, JObj, Validate, Attribute, Call2)
+    end.
+
+-spec maybe_add_passthrough_to_kvs(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> kapps_call:call().
+maybe_add_passthrough_to_kvs(Attribute, Endpoint, Call) ->
+    case kz_json:is_true([<<"caller_id">>, Attribute, <<"passthrough">>], Endpoint, 'false')
+        andalso kapps_config:get_is_true(?CONFIG_CAT, <<"allow_passthrough_caller_id">>, 'true')
+    of
+        'true' -> kapps_call:kvs_store('passthrough_caller_id', 'true', Call);
+        'false' -> Call
+    end.
+
+-spec get_endpoint_cid(kz_term:ne_binary(), kz_json:object(), kapps_call:call()) -> {kz_term:api_binary(), kz_term:api_ne_binary()}.
+get_endpoint_cid(Attribute, Endpoint, Call) ->
+    EndpointCLINumber = get_cid_or_default(Attribute, <<"number">>, Endpoint),
+    EndpointCLIName = get_cid_or_default(Attribute, <<"name">>, Endpoint),
+    _ = log_configured_endpoint_cid(Attribute, EndpointCLIName, EndpointCLINumber),
+    case kapps_call:kvs_fetch('passthrough_caller_id', 'false', Call) of
+        'true' ->
+            CCVs = kapps_call:custom_channel_vars(Call),
+            Name = kz_json:get_binary_value(<<"Original-Caller-ID-Name">>, CCVs),
+            Number = kz_json:get_binary_value(<<"Original-Caller-ID-Number">>, CCVs),
+            lager:debug("endpoint configured with passthrough for ~s; provided caller id: [~p] ~s", [Attribute, Name, Number]),
+            {Number, Name};
+        'false' ->
+            {EndpointCLINumber, EndpointCLIName}
     end.
 
 -spec maybe_add_originals_to_kvs(kz_term:api_ne_binary(), kz_term:api_ne_binary(), kapps_call:call()) -> kapps_call:call().
@@ -223,26 +248,143 @@ maybe_ensure_cid_valid(Number, Name, 'true', <<"emergency">>, _Call) ->
     lager:info("determined emergency caller id is <~s> ~s", [Name, Number]),
     {Number, Name};
 maybe_ensure_cid_valid(Number, Name, 'true', <<"external">>, Call) ->
-    case kapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_caller_id">>, 'false') of
-        'true' -> ensure_valid_caller_id(Number, Name, Call);
-        'false' ->
-            lager:info("determined external caller id is <~s> ~s", [Name, Number]),
-            {Number, Name}
+    AccountId = kapps_call:account_id(Call),
+    case kzd_accounts:fetch(AccountId) of
+        {'error', _E} ->
+            ?LOG_INFO("failed to open ~s: ~p", [AccountId, _E]),
+            maybe_get_account_cid(Number, Name, Call);
+        {'ok', AccountDoc} ->
+            case should_check_validity(AccountDoc, Call) of
+                'true' -> ensure_valid_caller_id(Number, Name, Call, AccountDoc);
+                'false' ->
+                    lager:info("determined external caller id is <~s> ~s", [Name, Number]),
+                    {Number, Name}
+            end
     end;
 maybe_ensure_cid_valid(Number, Name, _, Attribute, _Call) ->
     lager:info("determined ~s caller id is <~s> ~s", [Attribute, Name, Number]),
     {Number, Name}.
 
--spec ensure_valid_caller_id(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> cid().
-ensure_valid_caller_id(Number, Name, Call) ->
+%%%-----------------------------------------------------------------------------
+%%% @doc These 'should_check_validity' functions evaluate config parameters on
+%%% system_config/callflow and also the account document to determine if this
+%%% caller ID should be checked. There are these parameters:
+%%%  - system_config/callflow.ensure_valid_caller_id
+%%%  - system_config/callflow.ensure_valid_caller_id_owner
+%%%  - system_config/callflow.ensure_valid_passthrough_caller_id
+%%%  - system_config/callflow.ensure_valid_passthrough_caller_id_owner
+%%%  - {accountDoc}.caller_id_options.ensure_valid
+%%%  - {accountDoc}.caller_id_options.ensure_valid_owner
+%%%  - {accountDoc}.caller_id_options.passthrough_ensure_valid
+%%%  - {accountDoc}.caller_id_options.passthrough_ensure_valid_owner
+%%%  The passthrough options ONLY apply if passthrough caller ID is being used
+%%%  and the device is sending some arbitrary CLI into Kazoo. Passthrough CLI
+%%%  status is set on the Call KVs earlier in maybe_add_passthrough_to_kvs/3.
+%%%-----------------------------------------------------------------------------
+
+-spec should_check_validity(kz_json:object(), boolean() | kapps_call:call()) -> boolean().
+should_check_validity(AccountDoc, 'false') ->
+    kapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_caller_id">>, 'false')
+        orelse kzd_accounts:caller_id_options_ensure_valid(AccountDoc, 'false')
+        orelse should_check_validity_owner(AccountDoc, 'false');
+should_check_validity(AccountDoc, 'true') ->
+    case should_check_validity(AccountDoc, 'false') of
+        'true' -> 'true';
+        'false' ->
+            kapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_passthrough_caller_id">>, 'false')
+                orelse kzd_accounts:caller_id_options_passthrough_ensure_valid(AccountDoc, 'false')
+                orelse should_check_validity_owner(AccountDoc, 'true')
+    end;
+should_check_validity(AccountDoc, Call) ->
+    Passthrough = kapps_call:kvs_fetch('passthrough_caller_id', 'false', Call),
+    should_check_validity(AccountDoc, Passthrough).
+
+-spec should_check_validity_owner(kz_json:object(), boolean() | kapps_call:call()) -> boolean().
+should_check_validity_owner(AccountDoc, 'false') ->
+    kapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_caller_id_owner">>, 'false')
+        orelse kzd_accounts:caller_id_options_ensure_valid_owner(AccountDoc, 'false');
+should_check_validity_owner(AccountDoc, 'true') ->
+    case should_check_validity_owner(AccountDoc, 'false') of
+        'true' -> 'true';
+        'false' ->
+            kapps_config:get_is_true(<<"callflow">>, <<"ensure_valid_passthrough_caller_id_owner">>, 'false')
+                orelse kzd_accounts:caller_id_options_passthrough_ensure_valid_owner(AccountDoc, 'false')
+    end;
+should_check_validity_owner(AccountDoc, Call) ->
+    Passthrough = kapps_call:kvs_fetch('passthrough_caller_id', 'false', Call),
+    should_check_validity_owner(AccountDoc, Passthrough).
+
+-spec ensure_valid_caller_id(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call(), kz_json:object()) -> cid().
+ensure_valid_caller_id(Number, Name, Call, AccountDoc) ->
     case is_valid_caller_id(Number, Call) of
         'true' ->
-            lager:info("determined valid external caller id is <~s> ~s", [Name, Number]),
+            case should_check_validity_owner(AccountDoc, Call) of
+                'true' ->
+                    ensure_valid_caller_id_owner(Number, Name, Call);
+                'false' ->
+                    lager:info("determined valid external caller id is <~s> ~s", [Name, Number]),
+                    {Number, Name}
+            end;
+        'false' ->
+            lager:info("invalid external caller id <~s> ~s", [Name, Number]),
+            maybe_get_account_cid(Number, Name, Call)
+    end.
+
+-spec ensure_valid_caller_id_owner(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> cid().
+ensure_valid_caller_id_owner(Number, Name, Call) ->
+    case number_assigned_to_owner(Number, Call) of
+        'true' ->
+            lager:info("determined valid owner-assigned external caller id is <~s> ~s", [Name, Number]),
             {Number, Name};
         'false' ->
             lager:info("invalid external caller id <~s> ~s", [Name, Number]),
             maybe_get_account_cid(Number, Name, Call)
     end.
+
+-spec number_assigned_to_owner(kz_term:ne_binary(), kapps_call:call()) -> boolean().
+number_assigned_to_owner(Number, Call) ->
+    AccountId = kapps_call:account_id(Call),
+    OwnerId = kapps_call:owner_id(Call),
+    lager:debug("checking if this caller id number ~s belongs to owner ~s", [Number, OwnerId]),
+    case callflow_lookup(Number, AccountId) of
+        {'ok', NumberCallflow} ->
+            OwnerId =:= kz_json:get_ne_binary_value(<<"owner_id">>, NumberCallflow);
+        _Error -> 'false'
+    end.
+
+-spec callflow_lookup(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kzd_callflow:doc(), boolean()} | {'error', any()}.
+callflow_lookup(Number, AccountId) ->
+    case kz_cache:fetch_local(?CALLFLOW_CACHE_NAME, {'cf_flow', Number, AccountId}) of
+        {'ok', FlowId} -> kzd_callflows:fetch(AccountId, FlowId);
+        {'error', 'not_found'} -> callflow_number_db_lookup(Number, AccountId)
+    end.
+
+-spec callflow_number_db_lookup(kz_term:ne_binary(), kz_term:ne_binary()) -> {'ok', kzd_callflow:doc(), boolean()} | {'error', any()}.
+callflow_number_db_lookup(Number, AccountId) ->
+    Db = kz_util:format_account_db(AccountId),
+    lager:debug("searching for callflow in ~s to match '~s' with owner", [Db, Number]),
+    Options = [{'key', Number}, 'include_docs'],
+    case kz_datamgr:get_results(Db, <<"callflows/listing_by_number">>, Options) of
+        {'error', _}=E -> E;
+        {'ok', []} -> {'error', 'not_found'};
+        {'ok', [JObj]} ->
+            Flow = kz_json:get_value(<<"doc">>, JObj),
+            cache_callflow_number(Number, AccountId, Flow);
+        {'ok', [JObj | _Rest]} ->
+            lager:debug("lookup resulted in more than one result, using the first"),
+            Flow = kz_json:get_value(<<"doc">>, JObj),
+            cache_callflow_number(Number, AccountId, Flow)
+    end.
+
+-spec cache_callflow_number(kz_term:ne_binary(), kz_term:ne_binary(), kzd_callflow:doc()) ->
+          {'ok', kzd_callflow:doc(), boolean()} | {'error', any()}.
+cache_callflow_number(Number, AccountId, Flow) ->
+    AccountDb = kz_util:format_account_db(AccountId),
+    CacheOptions = [{'origin', [{'db', AccountDb, <<"callflow">>}]}
+                   ,{'expires', ?MILLISECONDS_IN_HOUR}
+                   ],
+    kz_cache:store_local(?CALLFLOW_CACHE_NAME, {'cf_flow', Number, AccountId}, kz_doc:id(Flow), CacheOptions),
+    {'ok', Flow}.
 
 -spec get_account_external_cid(kapps_call:call()) -> cid().
 get_account_external_cid(Call) ->


### PR DESCRIPTION
Caller ID Improvements

* Added system_config parameter to use P-Asserted-Identity header for privacy calls. This parameter makes Kazoo compliant for anonymous call requirements in Australia and other jurisdictions/carriers.
* Added passthrough caller ID option which allows a device to set arbitrary caller ID, as well as a system_config parameter which disables this feature. Passthrough caller ID will override the CID set elsewhere on the device/user/account. Normally this is used in conjunction with new config parameters that ensure a valid caller ID, either system-wide or at the account level.
* Added account option to ensure valid caller ID (system-wide was already implemented)
* Added account and system-wide options to ensure caller ID belongs to a particular user
