### PR TITLE
applications/stepswitch: add shortdial correction for faxes

### DIFF
--- a/applications/acdc/src/cf_acdc_agent.erl
+++ b/applications/acdc/src/cf_acdc_agent.erl
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2012-2020, 2600Hz
+%%% @copyright (C) 2012-2025, 2600Hz
 %%% @doc Handles changing an agent's status
 %%% "data":{
 %%%   "action":["login","logout","paused","resume", "toggle", "toggle_paused"] // one of these

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -32311,6 +32311,11 @@
                     "description": "Serialize fax transmissions by outbound number globally",
                     "type": "boolean"
                 },
+                "shortdial_correction": {
+                    "default": false,
+                    "description": "Perform shortdial correction on destination numbers",
+                    "type": "boolean"
+                },
                 "smtp_max_msg_size": {
                     "default": 10485670,
                     "description": "fax smtp maximum msg size",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
@@ -181,6 +181,11 @@
             "description": "Serialize fax transmissions by outbound number globally",
             "type": "boolean"
         },
+        "shortdial_correction": {
+            "default": false,
+            "description": "Perform shortdial correction on destination numbers",
+            "type": "boolean"
+        },
         "smtp_max_msg_size": {
             "default": 10485670,
             "description": "fax smtp maximum msg size",

--- a/applications/stepswitch/src/stepswitch_outbound.erl
+++ b/applications/stepswitch/src/stepswitch_outbound.erl
@@ -120,7 +120,27 @@ maybe_correct_shortdial(Number, OffnetReq) ->
             publish_no_resources(OffnetReq);
         CorrectedNumber ->
             lager:debug("corrected shortdial from '~s' to '~s', trying routing again", [Number, CorrectedNumber]),
-            handle_audio_req(CorrectedNumber, OffnetReq)
+            case kz_json:get_ne_binary_value(<<"Resource-Type">>, OffnetReq) of
+                <<"originate">> -> handle_originate_req(CorrectedNumber, OffnetReq);
+                _ -> handle_audio_req(CorrectedNumber, OffnetReq)
+            end
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Check application type, and see if kapps_config says that shortdial
+%% correction should be performed for that application type. The most common
+%% use for this is for fax-to-email where lazy users want to use local numbers
+%% and have the country/area code automatically prepended, based on the CLI.
+%% In the case of fax, the boolean system_config/fax.shortdial_correction
+%% parameter will enable or disable this functionality.
+%% @end
+%%------------------------------------------------------------------------------
+-spec maybe_correct_shortdial_originate(kz_term:ne_binary(), kapi_offnet_resource:req()) -> any().
+maybe_correct_shortdial_originate(Number, OffnetReq) ->
+    AppName = kz_json:get_ne_binary_value(<<"Application-Name">>, OffnetReq),
+    case kapps_config:get_boolean(AppName, <<"shortdial_correction">>) of
+        'true' -> maybe_correct_shortdial(Number, OffnetReq);
+        _ -> publish_no_resources(OffnetReq)
     end.
 
 %%------------------------------------------------------------------------------
@@ -140,7 +160,7 @@ local_extension(Props, OffnetReq) ->
 maybe_originate(Number, OffnetReq) ->
     RouteBy = stepswitch_util:route_by(),
     case RouteBy:endpoints(Number, OffnetReq) of
-        [] -> publish_no_resources(OffnetReq);
+        [] -> maybe_correct_shortdial_originate(Number, OffnetReq);
         Endpoints -> stepswitch_request_sup:originate(Endpoints, OffnetReq)
     end.
 

--- a/core/kazoo_amqp/src/kz_amqp_channel.erl
+++ b/core/kazoo_amqp/src/kz_amqp_channel.erl
@@ -220,7 +220,8 @@ basic_publish(#kz_amqp_assignment{channel=Channel
     MsgId = extract_msg_id(AmqpMsg#'amqp_msg'.payload),
     lager:debug("published(~s ~s) to ~s(~s) exchange (routing key ~s) via ~p"
                ,[MsgId, kz_util:pretty_print_bytes(iolist_size(AmqpMsg#'amqp_msg'.payload), 'truncated')
-                ,_Exchange, _Broker
+                ,_Exchange
+                ,kz_util:sanitize_uri(_Broker)
                 ,_RK
                 ,Channel
                 ]


### PR DESCRIPTION
Optional Shortdial Correction for Faxes

Added system_config/fax.shortdial_correction true/false which changes resource type requested by fax_worker, so that when sending faxes, lazy users can use a local number instead of the full number or E.164. :-)
This can also be enabled for other applications which use resource type of "originate" rather than "audio", by setting their `system_config/{application}.shortdial_correction` parameter to true.