### PR TITLE
applications/fax: add postfix domain lookup server

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -32286,15 +32286,15 @@
                     "description": "fax port",
                     "type": "integer"
                 },
-                "postfix_lookup": {
-                    "default": false,
-                    "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
-                    "type": "boolean"
-                },
                 "postfix_lookup_domain_port": {
                     "default": 19024,
                     "description": "port used for postfix_lookup_domain service",
                     "type": "integer"
+                },
+                "postfix_lookup_enabled": {
+                    "default": false,
+                    "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
+                    "type": "boolean"
                 },
                 "postfix_lookup_kazoo_transport": {
                     "default": "smtp:[127.0.0.1]:19025",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -32286,6 +32286,31 @@
                     "description": "fax port",
                     "type": "integer"
                 },
+                "postfix_lookup": {
+                    "default": false,
+                    "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
+                    "type": "boolean"
+                },
+                "postfix_lookup_domain_port": {
+                    "default": 19024,
+                    "description": "port used for postfix_lookup_domain service",
+                    "type": "integer"
+                },
+                "postfix_lookup_kazoo_transport": {
+                    "default": "smtp:[127.0.0.1]:19025",
+                    "description": "default transport pointing to Kazoo. Adjust as needed to point to Kazoo fax SMTP host/port, or HAProxy that load balances to it.",
+                    "type": "string"
+                },
+                "postfix_lookup_transport_port": {
+                    "default": 19023,
+                    "description": "port used for postfix_lookup_transport service. Used to determine if mail for a particular domain should be sent [inbound] to Kazoo or [outbound] to the internet.",
+                    "type": "integer"
+                },
+                "postfix_lookup_workers": {
+                    "default": 4,
+                    "description": "how many postfix_lookup server workers to run (for each lookup type)",
+                    "type": "integer"
+                },
                 "report_anonymous_system_errors": {
                     "default": false,
                     "description": "fax report anonymous system errors",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
@@ -156,6 +156,31 @@
             "description": "fax port",
             "type": "integer"
         },
+        "postfix_lookup": {
+            "default": false,
+            "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
+            "type": "boolean"
+        },
+        "postfix_lookup_domain_port": {
+            "default": 19024,
+            "description": "port used for postfix_lookup_domain service",
+            "type": "integer"
+        },
+        "postfix_lookup_kazoo_transport": {
+            "default": "smtp:[127.0.0.1]:19025",
+            "description": "default transport pointing to Kazoo. Adjust as needed to point to Kazoo fax SMTP host/port, or HAProxy that load balances to it.",
+            "type": "string"
+        },
+        "postfix_lookup_transport_port": {
+            "default": 19023,
+            "description": "port used for postfix_lookup_transport service. Used to determine if mail for a particular domain should be sent [inbound] to Kazoo or [outbound] to the internet.",
+            "type": "integer"
+        },
+        "postfix_lookup_workers": {
+            "default": 4,
+            "description": "how many postfix_lookup server workers to run (for each lookup type)",
+            "type": "integer"
+        },
         "report_anonymous_system_errors": {
             "default": false,
             "description": "fax report anonymous system errors",

--- a/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.fax.json
@@ -156,15 +156,15 @@
             "description": "fax port",
             "type": "integer"
         },
-        "postfix_lookup": {
-            "default": false,
-            "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
-            "type": "boolean"
-        },
         "postfix_lookup_domain_port": {
             "default": 19024,
             "description": "port used for postfix_lookup_domain service",
             "type": "integer"
+        },
+        "postfix_lookup_enabled": {
+            "default": false,
+            "description": "enable the postfix_lookup service which listens for Postfix tcp_table requests to authorize and route email domains",
+            "type": "boolean"
         },
         "postfix_lookup_kazoo_transport": {
             "default": "smtp:[127.0.0.1]:19025",

--- a/applications/fax/doc/postfix.md
+++ b/applications/fax/doc/postfix.md
@@ -20,8 +20,15 @@ Although you can expose kazoo fax on port 25 or use haproxy to relay incoming em
 
 ```
 relay_domains = hash:/etc/postfix/kz_smtp_domains
+# use the line below instead if you have enabled the postfix_lookup
+# server with system_config/fax.postfix_lookup = true.
+relay_domains = tcp:127.0.0.1:19024 # replace 127.0.0.1 with appropriate hostname or IP
+
 # relayhost should be the IP:PORT of haproxy-smtp-listener or kazoo fax whapp
 relayhost = 127.0.0.1:2525
+# OR if using postfix_lookup, comment relayhost and instead use this:
+transport_maps = tcp:127.0.0.1:19023 # replace 127.0.0.1 with appropriate hostname or IP
+
 
 policy-spf_time_limit = 3600s
 
@@ -37,7 +44,7 @@ smtpd_sender_restrictions =
     permit_mynetworks,
     reject_non_fqdn_sender,
     reject_unknown_sender_domain,
-     check_sender_access regexp:/etc/postfix/kz_allowed_senders,
+    #check_sender_access regexp:/etc/postfix/kz_allowed_senders, # optional
     reject
 
 smtpd_recipient_restrictions =
@@ -47,7 +54,7 @@ smtpd_recipient_restrictions =
    permit_mynetworks,
    reject_unauth_destination,
    check_policy_service unix:private/policyd-spf,
-   check_sender_access regexp:/etc/postfix/kz_allowed_senders,
+   #check_sender_access regexp:/etc/postfix/kz_allowed_senders, # optional
    reject_rbl_client zen.spamhaus.org,
    reject_rbl_client bl.spamcop.net,
    check_policy_service unix:postgrey/socket,
@@ -61,8 +68,7 @@ policy-spf  unix  -       n       n       -       0       spawn
 ```
 
 ## To-do
-* use CouchDB views to get kazoo faxboxes configuration into postfix
-* edit domains and permitted users from kazoo
+* use CouchDB views to get kazoo faxboxes configuration into postfix - DONE!
 * `postmap /etc/postfix/kz_smtp_domains`
 * `postmap /etc/postfix/kz_allowed_senders`
 * `postfix reload`

--- a/applications/fax/doc/postfix.md
+++ b/applications/fax/doc/postfix.md
@@ -21,7 +21,7 @@ Although you can expose kazoo fax on port 25 or use haproxy to relay incoming em
 ```
 relay_domains = hash:/etc/postfix/kz_smtp_domains
 # use the line below instead if you have enabled the postfix_lookup
-# server with system_config/fax.postfix_lookup = true.
+# server with system_config/fax.postfix_lookup_enabled = true.
 relay_domains = tcp:127.0.0.1:19024 # replace 127.0.0.1 with appropriate hostname or IP
 
 # relayhost should be the IP:PORT of haproxy-smtp-listener or kazoo fax whapp

--- a/applications/fax/src/fax_sup.erl
+++ b/applications/fax/src/fax_sup.erl
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2012-2022, 2600Hz
+%%% @copyright (C) 2012-2025, 2600Hz
 %%% @doc
 %%% @end
 %%%-----------------------------------------------------------------------------
@@ -36,6 +36,7 @@
                   ,?SUPER('fax_requests_sup')
                   ,?SUPER('fax_jobs_sup')
                   ,?SUPER('fax_worker_sup')
+                  ,?SUPER('postfix_lookup_sup')
                   ,?WORKER('fax_global_shared_listener')
                   ,?WORKER('fax_shared_listener')
                   ,?WORKER('fax_monitor')
@@ -82,7 +83,7 @@ smtp_sessions() ->
 %%------------------------------------------------------------------------------
 -spec init(any()) -> kz_types:sup_init_ret().
 init([]) ->
-    kz_util:set_startup(),
+    _ = kz_util:set_startup(),
     RestartStrategy = 'one_for_one',
     MaxRestarts = 5,
     MaxSecondsBetweenRestarts = 25,

--- a/applications/fax/src/postfix_lookup_domain.erl
+++ b/applications/fax/src/postfix_lookup_domain.erl
@@ -1,0 +1,80 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, RuhNet
+%%% @doc Postfix tcp_table server - implements Postfix client/server table
+%%% lookup protocol, for lookup of fax domains, so that Postfix can determine
+%%% whether or not to accept mail for that domain.
+%%% See https://www.postfix.org/tcp_table.5.html
+%%%
+%%% Request format is a single line: "get {key-to-lookup}\n"
+%%% Response format is one of:
+%%% not found response: "500 {not found message}\n"
+%%% error response:     "400 {error message}\n"  (client will retry later)
+%%% success response:   "200 {result}\n"
+%%%
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(postfix_lookup_domain).
+-behavior(gen_server).
+
+-export([start_link/1]).
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("fax.hrl").
+
+-define(SERVER, ?MODULE).
+
+-type state() :: gen_tcp:socket().
+
+-spec start_link(gen_tcp:socket()) -> kz_types:startlink_ret().
+start_link(LSocket) ->
+    gen_server:start_link(?MODULE, [LSocket], []).
+
+-spec init([gen_tcp:socket()]) -> {'ok', state()}.
+init([LSocket]) ->
+    gen_server:cast(self(), 'accept'),
+    {'ok', LSocket}.
+
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("terminating ~p worker: ~p", [?MODULE, _Reason]).
+
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+-spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    lager:debug("unhandled message: ~p", [_Info]),
+    {'noreply', State}.
+
+-spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
+handle_cast('accept', LSocket=_State) ->
+    _ = postfix_lookup_util:accept(LSocket, fun lookup_and_serve/2, ?MODULE), %% handle this request
+    gen_server:cast(self(), 'accept'), %% ready for accepting the next request
+    {'noreply', LSocket};
+handle_cast(_Msg, State) ->
+    lager:debug("unhandled cast: ~p", [_Msg]),
+    {'noreply', State}.
+
+-spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+-spec lookup_and_serve(gen_tcp:socket(), kz_term:ne_binary()) -> 'ok' | {'error', any()}.
+lookup_and_serve(Socket, ReqKey) ->
+    Res = case postfix_lookup_util:check_fax_domain(ReqKey) of
+              'ok' ->
+                  <<"200 OK\n">>;
+              'not_found' ->
+                  <<"500 not_found\n">>;
+              _ ->
+                  <<"400 error\n">>
+          end,
+    gen_tcp:send(Socket, Res).

--- a/applications/fax/src/postfix_lookup_sup.erl
+++ b/applications/fax/src/postfix_lookup_sup.erl
@@ -57,7 +57,7 @@ init([]) ->
                  ,{'packet', 'line'}
                  ,{'reuseaddr', 'true'}
                  ],
-    case kapps_config:get_is_true(?CONFIG_CAT, <<"postfix_lookup">>, 'false') of
+    case kapps_config:get_is_true(?CONFIG_CAT, <<"postfix_lookup_enabled">>, 'false') of
         'false' -> {'ok', {SupFlags, []}}; %% do nothing and keep the supervisor happy
         'true' ->
             case {gen_tcp:listen(?POSTFIX_LOOKUP_DOMAIN_PORT, ServerOpts)

--- a/applications/fax/src/postfix_lookup_sup.erl
+++ b/applications/fax/src/postfix_lookup_sup.erl
@@ -1,0 +1,71 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, RuhNet
+%%% @doc Supervisor for Postfix tcp_table server workers
+%%%
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(postfix_lookup_sup).
+-behavior(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+-include("fax.hrl").
+
+-define(SERVER, ?MODULE).
+
+-define(POSTFIX_LOOKUP_DOMAIN_PORT, kapps_config:get_integer(?CONFIG_CAT, <<"postfix_lookup_domain_port">>, 19024)).
+-define(POSTFIX_LOOKUP_TRANSPORT_PORT, kapps_config:get_integer(?CONFIG_CAT, <<"postfix_lookup_transport_port">>, 19023)).
+-define(POSTFIX_WORKER_COUNT, kapps_config:get_integer(?CONFIG_CAT, <<"postfix_lookup_workers">>, 4)).
+
+-define(WORKER_SPEC(Mod, Number, Args), {{Mod, Number},{Mod, 'start_link', Args}, 'permanent', 5000, 'worker', [Mod]}).
+
+-spec children(gen_tcp:socket(), gen_tcp:socket()) -> kz_types:sup_child_specs().
+children(LSocketDomain, LSocketTransport) ->
+    lager:notice("postfix lookup starting ~p domain lookup workers on port ~p", [?POSTFIX_WORKER_COUNT, ?POSTFIX_LOOKUP_DOMAIN_PORT]),
+    lager:notice("postfix lookup starting ~p transport lookup workers on port ~p", [?POSTFIX_WORKER_COUNT, ?POSTFIX_LOOKUP_TRANSPORT_PORT]),
+    DomainWorkers = [?WORKER_SPEC('postfix_lookup_domain', N, [LSocketDomain]) || N <- lists:seq(1, ?POSTFIX_WORKER_COUNT)],
+    TransportWorkers = [?WORKER_SPEC('postfix_lookup_transport', N, [LSocketTransport]) || N <- lists:seq(1, ?POSTFIX_WORKER_COUNT)],
+    DomainWorkers ++ TransportWorkers.
+
+%%------------------------------------------------------------------------------
+%% @doc Starts the supervisor.
+%% @end
+%%------------------------------------------------------------------------------
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    supervisor:start_link({'local', ?SERVER}, ?MODULE, []).
+
+%%------------------------------------------------------------------------------
+%% @doc Whenever a supervisor is started using `supervisor:start_link/[2,3]',
+%% this function is called by the new process to find out about
+%% restart strategy, maximum restart frequency and child
+%% specifications.
+%% @end
+%%------------------------------------------------------------------------------
+-spec init(any()) -> kz_types:sup_init_ret().
+init([]) ->
+    RestartStrategy = 'one_for_one',
+    MaxRestarts = 5,
+    MaxSecondsBetweenRestarts = 5,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    ServerOpts = [{'mode', 'binary'}
+                 ,{'active', 'false'}
+                 ,{'packet', 'line'}
+                 ,{'reuseaddr', 'true'}
+                 ],
+    case kapps_config:get_is_true(?CONFIG_CAT, <<"postfix_lookup">>, 'false') of
+        'false' -> {'ok', {SupFlags, []}}; %% do nothing and keep the supervisor happy
+        'true' ->
+            case {gen_tcp:listen(?POSTFIX_LOOKUP_DOMAIN_PORT, ServerOpts)
+                 ,gen_tcp:listen(?POSTFIX_LOOKUP_TRANSPORT_PORT, ServerOpts)
+                 }
+            of %% start listening socket and share it among workers
+                {{'ok', DSocket}, {'ok', TSocket}} -> {'ok', {SupFlags, children(DSocket, TSocket)}};
+                {{'error', Reason}, _} -> {'stop', Reason};
+                {_, {'error', Reason}} -> {'stop', Reason}
+            end
+    end.

--- a/applications/fax/src/postfix_lookup_transport.erl
+++ b/applications/fax/src/postfix_lookup_transport.erl
@@ -1,0 +1,83 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, RuhNet
+%%% @doc Postfix tcp_table server - implements Postfix client/server table
+%%% lookup protocol, for lookup of fax domains, so that Postfix can determine
+%%% the transport to use for them, whether to send them to Kazoo, or out to the
+%%% internet via normal delivery.
+%%% See https://www.postfix.org/tcp_table.5.html
+%%%
+%%% Request format is a single line: "get {key-to-lookup}\n"
+%%% Response format is one of:
+%%% not found response: "500 {not found message}\n"
+%%% error response:     "400 {error message}\n"  (client will retry later)
+%%% success response:   "200 {result}\n"
+%%%
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(postfix_lookup_transport).
+-behavior(gen_server).
+
+-export([start_link/1]).
+-export([init/1
+        ,handle_call/3
+        ,handle_cast/2
+        ,handle_info/2
+        ,terminate/2
+        ,code_change/3
+        ]).
+
+-include("fax.hrl").
+
+-define(SERVER, ?MODULE).
+
+-type state() :: gen_tcp:socket().
+
+-spec start_link(gen_tcp:socket()) -> kz_types:startlink_ret().
+start_link(LSocket) ->
+    gen_server:start_link(?MODULE, [LSocket], []).
+
+-spec init([gen_tcp:socket()]) -> {'ok', state()}.
+init([LSocket]) ->
+    gen_server:cast(self(), 'accept'),
+    {'ok', LSocket}.
+
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    lager:debug("terminating ~p worker: ~p", [?MODULE, _Reason]).
+
+-spec code_change(any(), state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {'ok', State}.
+
+-spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
+handle_info(_Info, State) ->
+    lager:debug("unhandled message: ~p", [_Info]),
+    {'noreply', State}.
+
+-spec handle_cast(any(), state()) -> kz_types:handle_cast_ret_state(state()).
+handle_cast('accept', LSocket=_State) ->
+    _ = postfix_lookup_util:accept(LSocket, fun lookup_and_serve/2, ?MODULE), %% handle this request
+    gen_server:cast(self(), 'accept'), %% ready for accepting the next request
+    {'noreply', LSocket};
+handle_cast(_Msg, State) ->
+    lager:debug("unhandled cast: ~p", [_Msg]),
+    {'noreply', State}.
+
+-spec handle_call(any(), kz_term:pid_ref(), state()) -> kz_types:handle_call_ret_state(state()).
+handle_call(_Request, _From, State) ->
+    {'reply', {'error', 'not_implemented'}, State}.
+
+-spec lookup_and_serve(gen_tcp:socket(), kz_term:ne_binary()) -> 'ok' | {'error', any()}.
+lookup_and_serve(Socket, ReqKey) ->
+    SMTPPort = kz_term:to_binary(?SMTP_PORT),
+    KZTransport = kapps_config:get_ne_binary(?CONFIG_CAT, <<"postfix_lookup_kazoo_transport">>, <<"smtp:[127.0.0.1]:", SMTPPort/binary>>),
+    Res = case postfix_lookup_util:check_fax_domain(ReqKey) of
+              'ok' ->
+                  <<KZTransport/binary, "\n">>;
+              'not_found' ->
+                  <<"smtp:\n">>; %% send using regular SMTP transport out to internet (this is outbound mail)
+              _ ->
+                  <<"400 error\n">>
+          end,
+    gen_tcp:send(Socket, Res).

--- a/applications/fax/src/postfix_lookup_transport.erl
+++ b/applications/fax/src/postfix_lookup_transport.erl
@@ -70,13 +70,14 @@ handle_call(_Request, _From, State) ->
 
 -spec lookup_and_serve(gen_tcp:socket(), kz_term:ne_binary()) -> 'ok' | {'error', any()}.
 lookup_and_serve(Socket, ReqKey) ->
+    Domain = postfix_lookup_util:domain_from_email(ReqKey),
     SMTPPort = kz_term:to_binary(?SMTP_PORT),
     KZTransport = kapps_config:get_ne_binary(?CONFIG_CAT, <<"postfix_lookup_kazoo_transport">>, <<"smtp:[127.0.0.1]:", SMTPPort/binary>>),
-    Res = case postfix_lookup_util:check_fax_domain(ReqKey) of
+    Res = case postfix_lookup_util:check_fax_domain(Domain) of
               'ok' ->
-                  <<KZTransport/binary, "\n">>;
+                  <<"200 ", KZTransport/binary, "\n">>;
               'not_found' ->
-                  <<"smtp:\n">>; %% send using regular SMTP transport out to internet (this is outbound mail)
+                  <<"200 smtp:\n">>; %% send using regular SMTP transport out to internet (this is outbound mail)
               _ ->
                   <<"400 error\n">>
           end,

--- a/applications/fax/src/postfix_lookup_util.erl
+++ b/applications/fax/src/postfix_lookup_util.erl
@@ -9,6 +9,7 @@
 
 -export([accept/3]).
 -export([check_fax_domain/1]).
+-export([domain_from_email/1]).
 
 -include("fax.hrl").
 
@@ -83,4 +84,11 @@ trim_newline(Binary) ->
     case Binary of
         <<Req:(Size)/binary, $\n>> -> Req;
         _ -> Binary
+    end.
+
+-spec domain_from_email(kz_term:ne_binary()) -> kz_term:ne_binary().
+domain_from_email(Address) ->
+    case binary:split(Address, <<"@">>) of
+        [_User, Domain] -> Domain;
+        _ -> Address
     end.

--- a/applications/fax/src/postfix_lookup_util.erl
+++ b/applications/fax/src/postfix_lookup_util.erl
@@ -1,0 +1,86 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, RuhNet
+%%% @doc Postfix tcp_table server lookup common utility functions
+%%%
+%%% @author Ruel Tmeizeh (www.ruhnet.co)
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(postfix_lookup_util).
+
+-export([accept/3]).
+-export([check_fax_domain/1]).
+
+-include("fax.hrl").
+
+-define(TIMEOUT, 8 * ?MILLISECONDS_IN_SECOND).
+
+-spec accept(gen_tcp:socket(), fun(), atom()) -> 'ok' | {'error', any()}.
+accept(LSocket, ServeFunc, ModuleName) ->
+    case gen_tcp:accept(LSocket) of
+        {'ok', AcceptSocket} ->
+            case handle_request(AcceptSocket, ServeFunc) of
+                'ok' -> 'ok';
+                {'error', Reason} -> lager:debug("~p failed to lookup and serve data: ~p", [ModuleName, Reason])
+            end,
+            gen_tcp:close(AcceptSocket);
+        {'error', Reason} -> lager:debug("~p accept connection failed: ~p", [ModuleName, Reason])
+    end.
+
+-spec handle_request(gen_tcp:socket(), fun()) -> 'ok' | {'error', any()}.
+handle_request(Socket, ServeFunc) ->
+    case gen_tcp:recv(Socket, 0, ?TIMEOUT) of
+        {'ok', ReqData} ->
+            case trim_newline(ReqData) of
+                <<"get UP">> -> %% health check
+                    gen_tcp:send(Socket, <<"500 UP\n">>);
+                <<"get ", ReqKey/binary>> -> %% valid request
+                    _ = gen_tcp:shutdown(Socket, 'read'), %% close the read part of the socket, since that is done
+                    ServeFunc(Socket, ReqKey);
+                _ ->
+                    _ = gen_tcp:send(Socket, <<"400 bad_request\n">>),
+                    {'error', 'invalid_request_format'}
+            end;
+        {'error', Reason}=Error ->
+            lager:debug("postfix lookup failed to receive data from client: ~p", [Reason]),
+            Error
+    end.
+
+-spec check_fax_domain(kz_term:ne_binary()) -> 'ok' | 'not_found' | kz_datamgr:get_results_return().
+check_fax_domain(Domain) ->
+    DomainL = kz_term:to_lower_binary(Domain),
+    case kz_cache:peek_local(?CACHE_NAME, {'fax_domain', DomainL}) of
+        {'ok', 'ok'} -> 'ok';
+        {'error', _} ->
+            case lookup_fax_domain(DomainL) of
+                'ok' ->
+                    kz_cache:store_local(?CACHE_NAME, {'fax_domain', Domain}, 'ok'),
+                    'ok';
+                NotFoundOrErr ->
+                    NotFoundOrErr
+            end
+    end.
+
+-spec lookup_fax_domain(kz_term:ne_binary()) -> 'ok' | 'not_found' | kz_datamgr:get_results_return().
+lookup_fax_domain(Domain) ->
+    ViewOptions = [{'key', Domain}],
+    case kz_datamgr:get_results(?KZ_FAXES_DB, <<"faxbox/email_address">>, ViewOptions) of
+        {'ok', [_|_]} -> 'ok';
+        _ -> lookup_account_realm(Domain)
+    end.
+
+-spec lookup_account_realm(kz_term:ne_binary()) -> 'ok' | 'not_found' | kz_datamgr:get_results_return().
+lookup_account_realm(Domain) ->
+    ViewOptions = [{'key', Domain}],
+    case kz_datamgr:get_results(?KZ_ACCOUNTS_DB, <<"accounts/listing_by_realm">>, ViewOptions) of
+        {'ok', []} -> 'not_found';
+        {'ok', [_|_]} -> 'ok';
+        {'error', _E}=Error -> Error
+    end.
+
+-spec trim_newline(kz_term:ne_binary()) -> kz_term:ne_binary().
+trim_newline(Binary) ->
+    Size = byte_size(Binary) - 1,
+    case Binary of
+        <<Req:(Size)/binary, $\n>> -> Req;
+        _ -> Binary
+    end.


### PR DESCRIPTION
Postfix Domain Lookup Server

Postfix has the capability to use a simple line-based TCP protocol to lookup entries as if it were a database: https://www.postfix.org/tcp_table.5.html
This code implements a server that uses that protocol and allows a Postfix instance to lookup fax domains, for inbound pre-filtering of SMTP requests, so that Kazoo itself will only have to deal with legitimate email-to-fax requests instead of spam attempts.

* Created Postfix domain lookup server
* Added transport lookup server
* Up check for HAProxy
* Move duplicated functions to a module, added local caching, docs
* extract domain from email address