### PR TITLE
applications/konami: refactor, fixes, simplification

### DIFF
--- a/applications/cdr/src/cdr_util.erl
+++ b/applications/cdr/src/cdr_util.erl
@@ -63,6 +63,8 @@ register_views() ->
     kz_datamgr:register_views_from_folder('cdr').
 
 -spec check_media_names(list()|kz_term:api_binary()| 'undefined') -> list() | 'undefined'.
+check_media_names([MediaName]) ->
+    re:split(MediaName, ",");
 check_media_names([HeadMN | TailMN]) ->
     re:split(HeadMN, ",") ++ check_last_media_name(TailMN);
 check_media_names('undefined') ->

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -523,7 +523,7 @@ col_other_leg_call_id(JObj, _Timestamp, _Context) -> kzd_cdrs:other_leg_call_id(
 col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
 col_custom_leg_vars(JObj, _Timestamp, _Context) ->
     Result = custom_leg_vars(JObj),
-    lager:debug("custom_leg_vars Result:~p", [Result]),
+    lager:debug("custom_leg_vars Result: ~p", [Result]),
     Result.
 col_to(JObj, _Timestamp, _Context) -> kzd_cdrs:to(JObj, <<>>).
 col_from(JObj, _Timestamp, _Context) -> kzd_cdrs:from(JObj, <<>>).

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -522,7 +522,9 @@ col_hangup_cause(JObj, _Timestamp, _Context) -> kzd_cdrs:hangup_cause(JObj, <<>>
 col_disposition(JObj, _Timestamp, _Context) -> kzd_cdrs:disposition(JObj, <<>>).
 col_other_leg_call_id(JObj, _Timestamp, _Context) -> kzd_cdrs:other_leg_call_id(JObj, <<>>).
 col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
-col_record_initiator_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"record_initiator_id">>], JObj, <<>>).
+col_record_initiator_id(JObj, _Timestamp, _Context) ->
+    lager:debug("JObj :~p",[JObj]),
+    kz_json:get_value([?KEY_CCV, <<"record_initiator_id">>], JObj, <<>>).
 col_record_start_at(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"record_start_at">>], JObj, <<>>).
 col_to(JObj, _Timestamp, _Context) -> kzd_cdrs:to(JObj, <<>>).
 col_from(JObj, _Timestamp, _Context) -> kzd_cdrs:from(JObj, <<>>).

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -88,6 +88,9 @@
         ,{<<"media_server">>, fun col_media_server/3}
         ,{<<"call_priority">>, fun col_call_priority/3}
         ,{<<"interaction_id">>, fun col_interaction_id/3}
+        %% New Circle Cloud Fields
+        ,{<<"record_initiator_id">>,fun col_record_initiator_id/3}
+        ,{<<"record_start_at">>,fun col_record_start_at/3}
         ]).
 
 -define(COLUMNS_RESELLER
@@ -519,6 +522,8 @@ col_hangup_cause(JObj, _Timestamp, _Context) -> kzd_cdrs:hangup_cause(JObj, <<>>
 col_disposition(JObj, _Timestamp, _Context) -> kzd_cdrs:disposition(JObj, <<>>).
 col_other_leg_call_id(JObj, _Timestamp, _Context) -> kzd_cdrs:other_leg_call_id(JObj, <<>>).
 col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
+col_record_initiator_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"record_initiator_id">>], JObj, <<>>).
+col_record_start_at(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"record_start_at">>], JObj, <<>>).
 col_to(JObj, _Timestamp, _Context) -> kzd_cdrs:to(JObj, <<>>).
 col_from(JObj, _Timestamp, _Context) -> kzd_cdrs:from(JObj, <<>>).
 col_call_direction(JObj, _Timestamp, _Context) -> kzd_cdrs:call_direction(JObj, <<>>).

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -88,7 +88,6 @@
         ,{<<"media_server">>, fun col_media_server/3}
         ,{<<"call_priority">>, fun col_call_priority/3}
         ,{<<"interaction_id">>, fun col_interaction_id/3}
-        %% New Circle Cloud Fields
         ,{<<"custom_leg_vars">>,fun col_custom_leg_vars/3}
         ]).
 
@@ -521,10 +520,7 @@ col_hangup_cause(JObj, _Timestamp, _Context) -> kzd_cdrs:hangup_cause(JObj, <<>>
 col_disposition(JObj, _Timestamp, _Context) -> kzd_cdrs:disposition(JObj, <<>>).
 col_other_leg_call_id(JObj, _Timestamp, _Context) -> kzd_cdrs:other_leg_call_id(JObj, <<>>).
 col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
-col_custom_leg_vars(JObj, _Timestamp, _Context) ->
-    Result = custom_leg_vars(JObj),
-    lager:debug("custom_leg_vars Result: ~p", [Result]),
-    Result.
+col_custom_leg_vars(JObj, _Timestamp, _Context) -> custom_leg_vars(JObj).
 col_to(JObj, _Timestamp, _Context) -> kzd_cdrs:to(JObj, <<>>).
 col_from(JObj, _Timestamp, _Context) -> kzd_cdrs:from(JObj, <<>>).
 col_call_direction(JObj, _Timestamp, _Context) -> kzd_cdrs:call_direction(JObj, <<>>).
@@ -691,6 +687,7 @@ load_legs(Id, Context) ->
 normalize_leg_view_results(JObj, Acc) ->
     Acc ++ [kz_json:get_json_value(<<"doc">>, JObj)].
 
+-spec custom_leg_vars(kz_json:object()) -> kz_json:object().
 custom_leg_vars(JObj)->
     Default = kz_json:new(),
     case kz_json:get_value([?KEY_CCV, <<"account_id">>], JObj, Default) of

--- a/applications/crossbar/src/modules/cb_cdrs.erl
+++ b/applications/crossbar/src/modules/cb_cdrs.erl
@@ -89,8 +89,7 @@
         ,{<<"call_priority">>, fun col_call_priority/3}
         ,{<<"interaction_id">>, fun col_interaction_id/3}
         %% New Circle Cloud Fields
-        ,{<<"record_initiator_id">>,fun col_record_initiator_id/3}
-        ,{<<"record_start_at">>,fun col_record_start_at/3}
+        ,{<<"custom_leg_vars">>,fun col_custom_leg_vars/3}
         ]).
 
 -define(COLUMNS_RESELLER
@@ -522,10 +521,10 @@ col_hangup_cause(JObj, _Timestamp, _Context) -> kzd_cdrs:hangup_cause(JObj, <<>>
 col_disposition(JObj, _Timestamp, _Context) -> kzd_cdrs:disposition(JObj, <<>>).
 col_other_leg_call_id(JObj, _Timestamp, _Context) -> kzd_cdrs:other_leg_call_id(JObj, <<>>).
 col_owner_id(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"owner_id">>], JObj, <<>>).
-col_record_initiator_id(JObj, _Timestamp, _Context) ->
-    lager:debug("JObj :~p",[JObj]),
-    kz_json:get_value([?KEY_CCV, <<"record_initiator_id">>], JObj, <<>>).
-col_record_start_at(JObj, _Timestamp, _Context) -> kz_json:get_value([?KEY_CCV, <<"record_start_at">>], JObj, <<>>).
+col_custom_leg_vars(JObj, _Timestamp, _Context) ->
+    Result = custom_leg_vars(JObj),
+    lager:debug("custom_leg_vars Result:~p", [Result]),
+    Result.
 col_to(JObj, _Timestamp, _Context) -> kzd_cdrs:to(JObj, <<>>).
 col_from(JObj, _Timestamp, _Context) -> kzd_cdrs:from(JObj, <<>>).
 col_call_direction(JObj, _Timestamp, _Context) -> kzd_cdrs:call_direction(JObj, <<>>).
@@ -691,3 +690,25 @@ load_legs(Id, Context) ->
           kz_json:objects().
 normalize_leg_view_results(JObj, Acc) ->
     Acc ++ [kz_json:get_json_value(<<"doc">>, JObj)].
+
+custom_leg_vars(JObj)->
+    Default = kz_json:new(),
+    case kz_json:get_value([?KEY_CCV, <<"account_id">>], JObj, Default) of
+        Default ->
+            Default;
+        AccountId ->
+            case kzd_cdrs:call_id(JObj, Default) of
+                Default->
+                    Default;
+                CallId ->
+                    DbName = kz_util:format_account_db(AccountId),
+                    case kz_datamgr:open_doc(DbName, CallId) of
+                        {error, Reason } ->
+                            lager:debug("custom_leg_vars error: ~p, DbName: ~p, CallId: ~p", [Reason, DbName, CallId]),
+                            Default;
+                        {ok, Doc} ->
+                            lager:debug("custom_leg_vars Doc: ~p", [Doc]),
+                            kz_json:get_value([<<"value">>], Doc, Default)
+                    end
+            end
+    end.

--- a/applications/ecallmgr/src/ecallmgr.hrl
+++ b/applications/ecallmgr/src/ecallmgr.hrl
@@ -35,6 +35,8 @@
 -define(DEFAULT_SAMPLE_RATE, kapps_config:get_integer(?APP_NAME, <<"record_sample_rate">>, 8000)).
 -define(DEFAULT_STEREO_SAMPLE_RATE, kapps_config:get_integer(?APP_NAME, <<"record_stereo_sample_rate">>, 16000)).
 
+-define(ALEG_CALLID_HEADER, kapps_config:get_ne_binary(?APP_NAME, <<"aleg_callid_header">>)).
+
 -type fs_app() :: {kz_term:ne_binary(), binary() | 'noop'} |
                   {kz_term:ne_binary(), kz_term:ne_binary(), atom()}.
 -type fs_apps() :: [fs_app()].

--- a/applications/ecallmgr/src/ecallmgr_fs_xml.erl
+++ b/applications/ecallmgr/src/ecallmgr_fs_xml.erl
@@ -313,6 +313,7 @@ route_resp_xml(<<"park">>, _Routes, JObj, Props) ->
              | route_resp_ccvs(JObj)
              ++ route_resp_cavs(JObj)
              ++ unset_custom_sip_headers(Props)
+             ++ maybe_emit_aleg_callid()
              ++ [action_el(<<"park">>)]
             ],
     ParkExtEl = extension_el(<<"park">>, 'undefined', [condition_el(Exten)]),
@@ -421,6 +422,13 @@ route_resp_ringback(JObj) ->
             MsgId = kz_json:get_value(<<"Msg-ID">>, JObj),
             Stream = ecallmgr_util:media_path(Media, 'extant', MsgId, JObj),
             action_el(<<"set">>, <<"ringback=", (kz_term:to_binary(Stream))/binary>>)
+    end.
+
+-spec maybe_emit_aleg_callid() -> kz_types:xml_el() | 'undefined'.
+maybe_emit_aleg_callid() ->
+    case ?ALEG_CALLID_HEADER of
+        'undefined' -> [];
+        HeaderName -> [action_el(<<"set">>, <<"sip_h_", HeaderName/binary, "=${uuid}">>)]
     end.
 
 -spec route_resp_ccvs(kz_json:object()) -> kz_types:xml_els().

--- a/applications/ecallmgr/src/ecallmgr_originate.erl
+++ b/applications/ecallmgr/src/ecallmgr_originate.erl
@@ -845,7 +845,29 @@ update_endpoint(Endpoint, #state{node=Node
 
     EP = kz_json:set_values([{<<"origination_uuid">>, Id}
                             ], Endpoint),
-    fix_hold_media(EP).
+    fix_hold_media(maybe_add_member_cid(EP, JObj)).
+
+maybe_add_member_cid(EP, JObj) ->
+    case member_call_id(JObj) of
+        undefined -> EP;
+        MemberCallId ->
+            maybe_add_aleg_callid(EP, MemberCallId)
+    end.
+
+maybe_add_aleg_callid(EP, MemberCallId) ->
+    case ?ALEG_CALLID_HEADER of
+        'undefined' -> EP;
+        HeaderName ->
+            add_aleg_callid(HeaderName, MemberCallId, EP)
+    end.
+
+member_call_id(JObj) ->
+    kz_json:get_ne_binary_value([<<"Custom-Channel-Vars">>, <<"Member-Call-ID">>], JObj).
+
+add_aleg_callid(HeaderName, MemberCallId, EP) ->
+    NewHeader = kz_json:set_value(HeaderName, MemberCallId, kz_json:new()),
+    CSH = kz_json:set_value(<<"Custom-SIP-Headers">>, NewHeader, kz_json:new()),
+    kz_json:merge(EP, CSH).
 
 -spec uuid_matches(created_uuid(), created_uuid()) -> boolean().
 uuid_matches({_, UUID}, {_, UUID}) -> 'true';

--- a/applications/konami/src/konami.app.src
+++ b/applications/konami/src/konami.app.src
@@ -2,7 +2,7 @@
              [{applications,[gproc,kazoo,kazoo_amqp,kazoo_apps,kazoo_call,
                              kazoo_data,kazoo_documents,kazoo_endpoint,
                              kazoo_events,kazoo_media,kazoo_stdlib,kernel,
-                             lager,stdlib,webseq]},
+                             amqp_leader,lager,stdlib,webseq]},
               {description,"Konami - Map in-call DTMF sequences to call features"},
               {env,[{is_kazoo_app,true}]},
               {mod,{konami_app,[]}},

--- a/applications/konami/src/konami_cache.erl
+++ b/applications/konami/src/konami_cache.erl
@@ -1,0 +1,25 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, Circle Cloud
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(konami_cache).
+
+-export([cache_or_fail/1]).
+
+-export([spec/0]).
+
+-include("konami.hrl").
+
+-spec cache_or_fail(any()) -> boolean().
+cache_or_fail(Key) ->
+    case kz_cache:fetch_local(?MODULE, Key) of
+        {'ok', 'true'} ->
+            'false';
+        {'error', 'not_found'} ->
+            kz_cache:store_local(?MODULE, Key, 'true'),
+            true
+    end.
+
+-spec spec() -> kz_types:sup_child_spec().
+spec() ->
+    ?CACHE(?MODULE).

--- a/applications/konami/src/konami_code_statem.erl
+++ b/applications/konami/src/konami_code_statem.erl
@@ -26,7 +26,7 @@
         ,code_change/4
         ]).
 
--export([format_status/1]).
+-export([format_status/2]).
 
 -include("konami.hrl").
 
@@ -228,16 +228,8 @@ handle_event(?EVENT(_CallId, <<"CHANNEL_ANSWER">>, Evt)
             ,State
             ) ->
     {'next_state', StateName, handle_channel_answer(State, kz_call_event:call_id(Evt), Evt)};
-handle_event(?EVENT(CallId, <<"CHANNEL_BRIDGE">>, Evt)
-            ,StateName
-            ,#state{call_id=CallId}=State
-            ) ->
-    {'next_state', StateName, handle_channel_bridge(State#state{other_leg=kz_call_event:other_leg_call_id(Evt)}, CallId, kz_call_event:other_leg_call_id(Evt))};
-handle_event(?EVENT(OtherLeg, <<"CHANNEL_BRIDGE">>, Evt)
-            ,StateName
-            ,#state{other_leg=OtherLeg}=State
-            ) ->
-    {'next_state', StateName, handle_channel_bridge(State#state{call_id=kz_call_event:other_leg_call_id(Evt)}, kz_call_event:other_leg_call_id(Evt), OtherLeg)};
+handle_event(?EVENT(_, <<"CHANNEL_BRIDGE">>, Evt), StateName, State) ->
+    {'next_state', StateName, handle_channel_bridge(State, Evt)};
 handle_event(?EVENT(CallId, <<"CHANNEL_DESTROY">>, _Evt)
             ,StateName
             ,#state{call_id=CallId}=State
@@ -277,8 +269,6 @@ terminate(_Reason, _StateName, #state{call_id=CallId
                                      }) ->
     konami_event_listener:rm_call_binding(CallId),
     konami_event_listener:rm_call_binding(OtherLeg),
-    konami_event_listener:rm_konami_binding(CallId),
-    konami_event_listener:rm_konami_binding(OtherLeg),
     ?WSD_STOP(),
     lager:debug("statem terminating while in ~s: ~p", [_StateName, _Reason]).
 
@@ -286,11 +276,11 @@ terminate(_Reason, _StateName, #state{call_id=CallId
 code_change(_OldVsn, StateName, State, _Extra) ->
     {'ok', StateName, State}.
 
--spec format_status(map()) -> map().
-format_status(#{state := #state{call_id=CallId
+-spec format_status(any(), [any(), state()]) -> any().
+format_status(_, [_Dict, #state{call_id=CallId
                                ,other_leg=OtherLeg
-                               }} = Status) ->
-    Status#{data=> [{"StateData", {CallId, OtherLeg}}]}.
+                               }]) ->
+    [{'data', [{"StateData", {CallId, OtherLeg}}]}].
 
 %%%=============================================================================
 %%% Internal functions
@@ -487,7 +477,6 @@ arm_bleg(#state{digit_timeout=Timeout}=State) ->
                ,b_leg_armed='true'
                }.
 
-
 -spec maybe_fast_rearm(kz_term:ne_binary(), kz_term:ne_binary(), binary()) -> binary().
 maybe_fast_rearm(DTMF, BindingDigit, Collected) ->
     maybe_fast_rearm(DTMF, BindingDigit, Collected
@@ -531,14 +520,10 @@ maybe_add_call_event_bindings(Call) -> konami_event_listener:add_call_binding(Ca
 
 -spec maybe_add_call_event_bindings(kapps_call:call(), listen_on()) -> 'ok'.
 maybe_add_call_event_bindings(Call, 'a') ->
-    konami_event_listener:add_konami_binding(kapps_call:call_id(Call)),
     maybe_add_call_event_bindings(Call);
 maybe_add_call_event_bindings(Call, 'b') ->
-    konami_event_listener:add_konami_binding(kapps_call:other_leg_call_id(Call)),
     maybe_add_call_event_bindings(Call);
 maybe_add_call_event_bindings(Call, 'ab') ->
-    konami_event_listener:add_konami_binding(kapps_call:call_id(Call)),
-    konami_event_listener:add_konami_binding(kapps_call:other_leg_call_id(Call)),
     maybe_add_call_event_bindings(Call).
 
 -spec b_endpoint_id(kz_json:object(), listen_on(), kz_term:ne_binary()) -> kz_term:api_binary().
@@ -593,68 +578,56 @@ maybe_other_leg_answered(#state{listen_on='b'
     State#state{other_leg=OtherLeg
                ,call=kapps_call:set_other_leg_call_id(OtherLeg, Call)
                };
-maybe_other_leg_answered(#state{listen_on='ab'
-                               ,call=Call
-                               }=State
-                        ,OtherLeg
-                        ,EndpointId
-                        ) ->
-    lager:debug("yay, our endpoint ~s answered on ~s", [EndpointId, OtherLeg]),
-    maybe_add_call_event_bindings(OtherLeg),
-    State#state{other_leg=OtherLeg
-               ,call=kapps_call:set_other_leg_call_id(OtherLeg, Call)
-               };
 maybe_other_leg_answered(State, _CallId, _EndpointId) ->
     lager:debug("ignoring channel ~s answering for endpoint ~s", [_CallId, _EndpointId]),
     State.
 
--spec handle_channel_bridge(state(), kz_term:ne_binary(), kz_term:ne_binary()) -> state().
-handle_channel_bridge(#state{call_id=CallId
-                            ,listen_on='a'
-                            ,call=Call
-                            }=State, CallId, OtherLeg) ->
-    lager:debug("joy, 'a' is bridged to ~s", [OtherLeg]),
-    State#state{call=kapps_call:set_other_leg_call_id(OtherLeg, Call)
-               ,other_leg=OtherLeg
-               };
-handle_channel_bridge(#state{call_id=CallId
-                            ,listen_on='b'
-                            }=State, CallId, _OtherLeg) ->
-    lager:debug("joy, 'b' is bridged to ~s. Removing binding to a-leg", [CallId]),
-    konami_event_listener:rm_call_binding(CallId),
-    konami_event_listener:rm_konami_binding(CallId),
-    State;
-handle_channel_bridge(#state{call_id=CallId
-                            ,other_leg=OtherLeg
-                            }=State, CallId, OtherLeg) ->
-    lager:debug("joy, 'a' and 'b' legs bridged"),
-    State;
-handle_channel_bridge(#state{other_leg='undefined'}
-                     ,_CallId
-                     ,_OtherLeg
-                     ) ->
-    lager:debug("'a' leg has bridged to other leg ~s...done here", [_OtherLeg]),
-    exit('normal');
-handle_channel_bridge(#state{call_id=_CallId
-                            ,other_leg=OtherLeg
-                            ,listen_on='a'
-                            }
-                     ,UUID
-                     ,OtherLeg
-                     ) ->
-    lager:debug("our 'b' leg ~s bridged to ~s instead of ~s", [OtherLeg, UUID, _CallId]),
-    exit('normal');
-handle_channel_bridge(#state{call_id=_CallId
-                            ,other_leg=OtherLeg
-                            ,call=Call
-                            }=State
-                     ,UUID
-                     ,OtherLeg
-                     ) ->
-    lager:debug("our 'b' leg ~s bridged to ~s instead of ~s", [OtherLeg, UUID, _CallId]),
-    State#state{call_id=UUID
-               ,call=kapps_call:set_call_id(UUID, Call)
-               }.
+-spec handle_channel_bridge(state(), kz_json:object()) -> state().
+handle_channel_bridge(#state{call_id=CallId, other_leg=OtherLeg, listen_on='ab'}=State
+                     ,Evt) ->
+    BridgeId = kz_call_event:call_id(Evt),
+    BridgeTo = kz_call_event:other_leg_call_id(Evt),
+    case {CallId, OtherLeg} of
+        {BridgeId, _} ->
+            maybe_add_call_event_bindings(BridgeTo),
+            State#state{other_leg = BridgeTo};
+        {BridgeTo, _} ->
+            maybe_add_call_event_bindings(BridgeId),
+            State#state{other_leg = BridgeId};
+        {_, BridgeId} ->
+            maybe_add_call_event_bindings(BridgeTo),
+            State#state{call_id = BridgeTo};
+        {_, BridgeTo} ->
+            maybe_add_call_event_bindings(BridgeId),
+            State#state{call_id = BridgeId};
+        _ -> State
+    end;
+handle_channel_bridge(#state{call_id = CallId, listen_on = 'a'} = State, Evt) ->
+    BridgeId = kz_call_event:call_id(Evt),
+    BridgeTo = kz_call_event:other_leg_call_id(Evt),
+    case CallId of
+        BridgeId ->
+            maybe_add_call_event_bindings(BridgeTo),
+            State#state{other_leg = BridgeTo};
+        BridgeTo ->
+            maybe_add_call_event_bindings(BridgeId),
+            State#state{other_leg = BridgeId};
+        _ -> State
+    end;
+handle_channel_bridge(#state{other_leg = OtherLeg, listen_on = 'b'} = State, Evt) ->
+    BridgeId = kz_call_event:call_id(Evt),
+    BridgeTo = kz_call_event:other_leg_call_id(Evt),
+    case OtherLeg of
+        BridgeId ->
+            maybe_add_call_event_bindings(BridgeTo),
+            State#state{call_id = BridgeTo};
+        BridgeTo ->
+            maybe_add_call_event_bindings(BridgeId),
+            State#state{call_id = BridgeId};
+        _ -> exit('normal')
+    end;
+handle_channel_bridge(State, _Evt) ->
+    State.
 
 -spec handle_channel_destroy(state(), kz_term:ne_binary()) -> state().
 handle_channel_destroy(#state{call_id=CallId
@@ -687,6 +660,12 @@ handle_channel_destroy(#state{other_leg=OtherLeg
                       ,OtherLeg
                       ) ->
     lager:debug("'b' ~s has ended, so should we", [OtherLeg]),
+    exit('normal');
+handle_channel_destroy(#state{call_id='undefined'
+                             ,other_leg=OtherLeg}
+                      ,OtherLeg
+                      ) ->
+    lager:debug("'b' ~s has ended and we have not 'a' leg"),
     exit('normal');
 handle_channel_destroy(#state{other_leg=OtherLeg
                              ,call=Call

--- a/applications/konami/src/konami_code_statem.erl
+++ b/applications/konami/src/konami_code_statem.erl
@@ -232,12 +232,12 @@ handle_event(?EVENT(CallId, <<"CHANNEL_BRIDGE">>, Evt)
             ,StateName
             ,#state{call_id=CallId}=State
             ) ->
-    {'next_state', StateName, handle_channel_bridge(State, CallId, kz_call_event:other_leg_call_id(Evt))};
+    {'next_state', StateName, handle_channel_bridge(State#state{other_leg=kz_call_event:other_leg_call_id(Evt)}, CallId, kz_call_event:other_leg_call_id(Evt))};
 handle_event(?EVENT(OtherLeg, <<"CHANNEL_BRIDGE">>, Evt)
             ,StateName
             ,#state{other_leg=OtherLeg}=State
             ) ->
-    {'next_state', StateName, handle_channel_bridge(State, kz_call_event:other_leg_call_id(Evt), OtherLeg)};
+    {'next_state', StateName, handle_channel_bridge(State#state{call_id=kz_call_event:other_leg_call_id(Evt)}, kz_call_event:other_leg_call_id(Evt), OtherLeg)};
 handle_event(?EVENT(CallId, <<"CHANNEL_DESTROY">>, _Evt)
             ,StateName
             ,#state{call_id=CallId}=State
@@ -583,6 +583,17 @@ maybe_other_leg_answered(#state{listen_on='b'
     lager:debug("ignoring channel -s answering for endpoint ~s", [CallId, EndpointId]),
     State;
 maybe_other_leg_answered(#state{listen_on='b'
+                               ,call=Call
+                               }=State
+                        ,OtherLeg
+                        ,EndpointId
+                        ) ->
+    lager:debug("yay, our endpoint ~s answered on ~s", [EndpointId, OtherLeg]),
+    maybe_add_call_event_bindings(OtherLeg),
+    State#state{other_leg=OtherLeg
+               ,call=kapps_call:set_other_leg_call_id(OtherLeg, Call)
+               };
+maybe_other_leg_answered(#state{listen_on='ab'
                                ,call=Call
                                }=State
                         ,OtherLeg

--- a/applications/konami/src/konami_event_listener.erl
+++ b/applications/konami/src/konami_event_listener.erl
@@ -7,9 +7,8 @@
 -behaviour(gen_listener).
 
 -export([start_link/0
-        ,add_call_binding/1, add_call_binding/2
-        ,rm_call_binding/1, rm_call_binding/2
-        ,add_konami_binding/1, rm_konami_binding/1
+        ,add_call_binding/1
+        ,rm_call_binding/1
         ,handle_call_event/2
         ,handle_originate_event/2
         ,handle_metaflow_req/2
@@ -28,8 +27,6 @@
         ,handle_event/2
         ,terminate/2
         ,code_change/3
-
-        ,cleanup_bindings/1
         ]).
 
 -include("konami.hrl").
@@ -37,8 +34,7 @@
 
 -define(SERVER, ?MODULE).
 
--record(state, {cleanup_ref :: reference()
-               }).
+-record(state, {}).
 -type state() :: #state{}.
 
 -define(CLEANUP_TIMEOUT
@@ -46,7 +42,17 @@
        ).
 
 %% By convention, we put the options here in macros, but not required.
--define(BINDINGS, [{'self', []}]).
+-define(BINDINGS, [{'self', []}
+                  ,{'call', [{'restrict_to', ?TRACKED_CALL_EVENTS}]}
+                  ,{'metaflow', [{'callid', <<"*">>}
+                                ,{'action', <<"*">>}
+                                ,{'restrict_to', ['action']}
+                                ,'federate'
+                                ]}
+                  ,{'konami', [{'callid', <<"*">>}
+                              ,{'restrict_to', ['transferred']}
+                              ]}
+                  ]).
 -define(RESPONDERS, [{{?MODULE, 'handle_call_event'}
                      ,[{<<"call_event">>, <<"*">>}
                       ,{<<"error">>, <<"*">>}
@@ -70,30 +76,17 @@
 
 -define(TRACKED_CALL_EVENTS, [<<"CHANNEL_ANSWER">>
                              ,<<"CHANNEL_BRIDGE">>
+                             ,<<"CHANNEL_CREATE">>
                              ,<<"CHANNEL_DESTROY">>
                              ,<<"CHANNEL_REPLACED">>
                              ,<<"CHANNEL_TRANSFEREE">>
+                             ,<<"CHANNEL_UNBRIDGE">>
                              ,<<"DTMF">>
+                             ,<<"LEG_CREATED">>
+                             ,<<"LEG_DESTROYED">>
+                             ,<<"dialplan">>
                              ]).
 
--define(DYN_BINDINGS(CallId), 'call', [{'restrict_to', ?TRACKED_CALL_EVENTS}
-                                      ,{'callid', CallId}
-                                      ]
-       ).
--define(DYN_BINDINGS(CallId, Events), 'call', [{'restrict_to', Events}
-                                              ,{'callid', CallId}
-                                              ]
-       ).
--define(META_BINDINGS(CallId), 'metaflow', [{'callid', CallId}
-                                           ,{'action', <<"*">>}
-                                           ,{'restrict_to', ['action']}
-                                           ,'federate'
-                                           ]
-       ).
--define(KONAMI_BINDINGS(CallId), 'konami', [{'callid', CallId}
-                                           ,{'restrict_to', ['transferred']}
-                                           ]
-       ).
 -define(KONAMI_REG(CallId), {'p', 'l', {'konami_event', CallId}}).
 
 %%%=============================================================================
@@ -130,77 +123,18 @@ bindings(CallId) ->
         props:get_value('callid', Props) =:= CallId
     ].
 
--spec add_konami_binding(kz_term:api_binary()) -> 'ok'.
-add_konami_binding('undefined') -> 'ok';
-add_konami_binding(CallId) ->
-    gen_listener:add_binding(?SERVER, ?KONAMI_BINDINGS(CallId)).
-
--spec rm_konami_binding(kz_term:api_binary()) -> 'ok'.
-rm_konami_binding('undefined') -> 'ok';
-rm_konami_binding(<<_/binary>> = CallId) ->
-    gen_listener:rm_binding(?SERVER, ?KONAMI_BINDINGS(CallId)).
-
 -spec add_call_binding(kz_term:api_ne_binary() | kapps_call:call()) -> 'ok'.
 add_call_binding('undefined') -> 'ok';
 add_call_binding(CallId) when is_binary(CallId) ->
     lager:debug("add fsm binding for call ~s: ~p", [CallId, ?TRACKED_CALL_EVENTS]),
-    catch gproc:reg(?KONAMI_REG({'fsm', CallId})),
-    gen_listener:b_add_binding(?SERVER, ?DYN_BINDINGS(CallId, ?TRACKED_CALL_EVENTS)),
-    gen_listener:b_add_binding(?SERVER, ?META_BINDINGS(CallId));
+    gproc_reg(?KONAMI_REG({'fsm', CallId}));
 add_call_binding(Call) ->
-    gen_listener:cast(?SERVER, {'add_account_events', kapps_call:account_id(Call)}),
-    catch gproc:reg(?KONAMI_REG({'fsm', kapps_call:account_id(Call)})),
     add_call_binding(kapps_call:call_id_direct(Call)).
-
--spec add_call_binding(kz_term:api_ne_binary() | kapps_call:call(), kz_term:ne_binaries() | kz_term:atoms()) -> 'ok'.
-add_call_binding('undefined', _) -> 'ok';
-add_call_binding(CallId, Events) when is_binary(CallId) ->
-    lager:debug("add pid binding for call ~s: ~p", [CallId, Events]),
-    catch gproc:reg(?KONAMI_REG({'pid', CallId})),
-    gen_listener:b_add_binding(?SERVER, ?DYN_BINDINGS(CallId, Events)),
-    gen_listener:b_add_binding(?SERVER, ?META_BINDINGS(CallId));
-add_call_binding(Call, Events) ->
-    gen_listener:cast(?SERVER, {'add_account_events', kapps_call:account_id(Call)}),
-    catch gproc:reg(?KONAMI_REG({'pid', kapps_call:account_id(Call)})),
-    add_call_binding(kapps_call:call_id_direct(Call), Events).
 
 -spec rm_call_binding(kz_term:api_ne_binary() | kapps_call:call()) -> 'ok'.
 rm_call_binding('undefined') -> 'ok';
 rm_call_binding(CallId) ->
-    catch gproc:unreg(?KONAMI_REG({'fsm', CallId})),
-    case call_has_listeners(CallId) of
-        'true' -> 'ok';
-        'false' -> really_remove_call_bindings(CallId)
-    end.
-
--spec rm_call_binding(kz_term:api_binary(), kz_term:ne_binaries()) -> 'ok'.
-rm_call_binding('undefined', _Evts) -> 'ok';
-rm_call_binding(CallId, Events) ->
-    catch gproc:unreg(?KONAMI_REG({'pid', CallId})),
-    case call_has_listeners(CallId) of
-        'true' -> 'ok';
-        'false' -> really_remove_call_bindings(CallId, Events)
-    end.
-
--spec call_has_listeners(kz_term:ne_binary()) -> boolean().
-call_has_listeners(CallId) ->
-    Self = self(),
-    case {fsms_for_callid(CallId), pids_for_callid(CallId)} of
-        {[], []} -> 'false';
-        {[Self], []} -> 'false';
-        {[], [Self]} -> 'false';
-        {[Self], [Self]} -> 'false';
-        _ -> 'true'
-    end.
-
--spec really_remove_call_bindings(kz_term:ne_binary()) -> 'ok'.
-really_remove_call_bindings(CallId) ->
-    really_remove_call_bindings(CallId, ?TRACKED_CALL_EVENTS).
-
--spec really_remove_call_bindings(kz_term:ne_binary(), kz_term:ne_binaries()) -> 'ok'.
-really_remove_call_bindings(CallId, Events) ->
-    gen_listener:rm_binding(?SERVER, ?DYN_BINDINGS(CallId, Events)),
-    gen_listener:rm_binding(?SERVER, ?META_BINDINGS(CallId)).
+    catch gproc:unreg(?KONAMI_REG({'fsm', CallId})).
 
 -spec handle_call_event(kz_json:object(), kz_term:proplist()) -> any().
 handle_call_event(JObj, Props) ->
@@ -214,9 +148,14 @@ handle_call_event(JObj, _Props, <<"CHANNEL_DESTROY">> = Event) ->
     _ = relay_to_pids(CallId, JObj),
     _ = relay_to_fsms(CallId, Event, JObj),
     rm_call_binding(CallId);
+handle_call_event(JObj, _Props, <<"CHANNEL_BRIDGE">> = Event) ->
+    CallId = kz_call_event:call_id(JObj),
+    OtherLegId = kz_call_event:other_leg_call_id(JObj),
+    _ = relay_to_fsms(CallId, Event, JObj),
+    _ = relay_to_fsms(OtherLegId, CallId, Event, JObj),
+    relay_to_pids(CallId, JObj);
 handle_call_event(JObj, _Props, Event) ->
     CallId = kz_call_event:call_id(JObj),
-
     _ = relay_to_fsms(CallId, Event, JObj),
     relay_to_pids(CallId, JObj).
 
@@ -255,8 +194,12 @@ queue_name() -> gen_listener:queue_name(?SERVER).
 
 -spec relay_to_fsms(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> any().
 relay_to_fsms(CallId, Event, JObj) ->
+    relay_to_fsms(CallId, CallId, Event, JObj).
+
+-spec relay_to_fsms(kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> any().
+relay_to_fsms(FsmCallId, CallId, Event, JObj) ->
     [konami_code_statem:event(FSM, CallId, Event, JObj)
-     || FSM <- fsms_for_callid(CallId)
+     || FSM <- fsms_for_callid(FsmCallId)
     ].
 
 -spec fsms_for_callid(kz_term:api_ne_binary() | '_') -> kz_term:pids().
@@ -279,8 +222,12 @@ metaflows() ->
 
 -spec relay_to_fsm(kz_term:ne_binary(), kz_term:ne_binary(), kz_json:object()) -> any().
 relay_to_fsm(CallId, Event, JObj) ->
-    [FSM | _] = fsms_for_callid(CallId),
-    konami_code_statem:event(FSM, CallId, Event, JObj).
+    case fsms_for_callid(CallId) of
+        [FSM | _] ->
+            konami_code_statem:event(FSM, CallId, Event, JObj);
+        _Else ->
+            'ok'
+    end.
 
 -spec relay_to_pids(kz_term:ne_binary(), kz_json:object()) -> any().
 relay_to_pids(CallId, JObj) ->
@@ -313,10 +260,7 @@ originate(Req) ->
 %%------------------------------------------------------------------------------
 -spec init([]) -> {'ok', state()}.
 init([]) ->
-    {'ok', #state{cleanup_ref=cleanup_timer()}}.
-
-cleanup_timer() ->
-    erlang:start_timer(?CLEANUP_TIMEOUT, self(), 'ok').
+    {'ok', #state{}}.
 
 %%------------------------------------------------------------------------------
 %% @doc Handling call messages.
@@ -338,10 +282,6 @@ handle_cast({'gen_listener', {'created_queue', _QueueNAme}}, State) ->
     {'noreply', State};
 handle_cast({'gen_listener', {'is_consuming', _IsConsuming}}, State) ->
     {'noreply', State};
-handle_cast({'add_account_events', AccountId}, State) ->
-    lager:debug("registering for account events for ~s", [AccountId]),
-    kz_hooks:register(AccountId, <<"CHANNEL_ANSWER">>),
-    {'noreply', State};
 handle_cast(_Msg, State) ->
     lager:debug("unhandled cast: ~p", [_Msg]),
     {'noreply', State}.
@@ -351,12 +291,6 @@ handle_cast(_Msg, State) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec handle_info(any(), state()) -> kz_types:handle_info_ret_state(state()).
-handle_info(?HOOK_EVT(AccountId, <<"CHANNEL_ANSWER">> = EventName, Event), State) ->
-    _ = relay_to_fsms(AccountId, EventName, Event),
-    {'noreply', State};
-handle_info({'timeout', Ref, _Msg}, #state{cleanup_ref=Ref}=State) ->
-    _P = kz_util:spawn(fun cleanup_bindings/1, [self()]),
-    {'noreply', State#state{cleanup_ref=cleanup_timer()}};
 handle_info(_Info, State) ->
     {'noreply', State}.
 
@@ -396,24 +330,10 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc
 %% @end
 %%------------------------------------------------------------------------------
--spec cleanup_bindings(kz_types:server_ref()) -> 'ok'.
-cleanup_bindings(Srv) ->
-    kz_util:put_callid(?MODULE),
-    cleanup_bindings(Srv, gen_listener:bindings(Srv)).
-
--spec cleanup_bindings(kz_types:server_ref(), gen_listener:bindings()) -> 'ok'.
-cleanup_bindings(_Srv, []) -> 'ok';
-cleanup_bindings(Srv, [{Binding, Props}|Bindings]) ->
-    maybe_remove_binding(Srv, Binding, Props, props:get_value('callid', Props)),
-    cleanup_bindings(Srv, Bindings).
-
--spec maybe_remove_binding(kz_types:server_ref(), atom(), kz_term:proplist(), kz_term:api_binary()) -> 'ok'.
-maybe_remove_binding(_Srv, _Binding, _Props, 'undefined') -> 'ok';
-maybe_remove_binding(Srv, Binding, Props, CallId) ->
-    case {fsms_for_callid(CallId), pids_for_callid(CallId)} of
-        {[], []} ->
-            lager:debug("~p: no pids for call-id '~s', removing binding '~s'", [Srv, CallId, Binding]),
-            gen_listener:rm_binding(Srv, Binding, Props);
-        {_FSMs, _Pids} ->
-            lager:debug("binding ~p still has FSMs: ~p and pids: ~p", [Binding, _FSMs, _Pids])
+gproc_reg(Key) ->
+    case gproc:lookup_pids(Key) of
+        [] ->
+            catch gproc:reg(Key);
+        _ ->
+            'false'
     end.

--- a/applications/konami/src/konami_leader.erl
+++ b/applications/konami/src/konami_leader.erl
@@ -1,0 +1,92 @@
+%%%-----------------------------------------------------------------------------
+%%% @copyright (C) 2025-2025, Circle Cloud
+%%% @end
+%%%-----------------------------------------------------------------------------
+-module(konami_leader).
+
+-export([cache_or_fail/1]).
+
+-export([spec/0]).
+-export([start_link/0]).
+
+-export([init/1]).
+-export([elected/3]).
+-export([surrendered/3]).
+-export([from_leader/3]).
+-export([handle_DOWN/3]).
+-export([handle_leader_call/4]).
+-export([handle_leader_cast/3]).
+-export([handle_call/4]).
+-export([handle_cast/3]).
+-export([handle_info/3]).
+-export([terminate/2]).
+-export([code_change/4]).
+
+-include("konami.hrl").
+
+-record(state, {}).
+-type state() :: #state{}.
+-type shared_state() :: any().
+
+-spec cache_or_fail(any()) -> boolean().
+cache_or_fail(Key) ->
+    amqp_leader_proc:leader_call(?MODULE, {'cache_or_fail', Key}).
+
+-spec spec() -> kz_types:sup_child_spec().
+spec() ->
+    ?SUPER(?MODULE).
+
+-spec start_link() -> kz_types:startlink_ret().
+start_link() ->
+    amqp_leader:start_link(?MODULE, [node()], [], ?MODULE, [], []).
+
+-spec init(_) -> {'ok', state()}.
+init([]) ->
+    {'ok', #state{}}.
+
+-spec elected(state(), state(), shared_state()) -> {'ok', state(), state()}.
+elected(State, _, _) ->
+    {'ok', State, State}.
+
+-spec surrendered(state(), any(), any()) -> {'ok', state()}.
+surrendered(State, _, _) ->
+    {'ok', State}.
+
+-spec from_leader(any(), state(), shared_state()) -> {'ok', state()}.
+from_leader(_Msg, State, _SharedState) ->
+    {'ok', State}.
+
+-spec handle_DOWN(atom(), state(), shared_state()) -> {'ok', state()}.
+handle_DOWN(_Node, State, _SharedState) ->
+    {'ok', State}.
+
+-spec handle_leader_call(any(), kz_term:pid_ref(), state(), shared_state()) -> kz_types:handle_call_ret_state(state()).
+handle_leader_call({'cache_or_fail', Key}, _From, State, _SharedState) ->
+    Reply = konami_cache:cache_or_fail(Key),
+    {'reply', Reply, State};
+handle_leader_call(_Msg, _From, State, _SharedState) ->
+    {'reply', {'error', 'unspecified'}, State}.
+
+-spec handle_leader_cast(any(), state(), shared_state()) -> kz_types:handle_cast_ret_state(state()).
+handle_leader_cast(_Msg, State, _SharedState) ->
+    {'noreply', State}.
+
+-spec handle_call(any(), kz_term:pid_ref(), state(), shared_state()) -> kz_types:handle_call_ret_state(state()).
+handle_call(_Msg, _From, State, _SharedState) ->
+    {'reply', {'error', 'unspecified'}, State}.
+
+-spec handle_cast(any(), state(), shared_state()) -> kz_types:handle_info_ret_state(state()).
+handle_cast(_Msg, State, _SharedState) ->
+    {'noreply', State}.
+
+-spec handle_info(any(), state(), shared_state()) -> kz_types:handle_info_ret_state(state()).
+handle_info(_Msg, State, _SharedState) ->
+    {'noreply', State}.
+
+-spec terminate(any(), state()) -> 'ok'.
+terminate(_Reason, _State) ->
+    'ok'.
+
+-spec code_change(any(), state(), shared_state(), any()) -> {'ok', state()}.
+code_change(_OldVsn, State, _SharedState, _Extra) ->
+    {'ok', State}.

--- a/applications/konami/src/konami_listener.erl
+++ b/applications/konami/src/konami_listener.erl
@@ -69,9 +69,12 @@ handle_metaflow(JObj, Props) ->
     Call = kapps_call:from_json(kz_json:get_value(<<"Call">>, JObj)),
     kapps_call:put_callid(Call),
 
-    _ = konami_code_statem:start(kapps_call:kvs_store('consumer_pid', props:get_value('server', Props), Call)
-                                ,JObj
-                                ),
+    konami_leader:cache_or_fail({'call_id', kapps_call:call_id(Call)})
+        andalso konami_code_statem:start(kapps_call:kvs_store('consumer_pid'
+                                                             ,props:get_value('server', Props)
+                                                             ,Call)
+                                        ,JObj
+                                        ),
     'ok'.
 
 -spec handle_route_req(kz_json:object(), kz_term:proplist()) -> 'ok'.

--- a/applications/konami/src/konami_sup.erl
+++ b/applications/konami/src/konami_sup.erl
@@ -15,7 +15,9 @@
 -define(SERVER, ?MODULE).
 
 %% Helper macro for declaring children of supervisor
--define(CHILDREN, [?WORKER('konami_listener')
+-define(CHILDREN, [konami_cache:spec()
+                  ,konami_leader:spec()
+                  ,?WORKER('konami_listener')
                   ,?WORKER('konami_event_listener')
                   ,?WORKER('konami_init')
                   ]).

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,12 +35,12 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-    lager:debug("Call:~ p",[Call]),
+    lager:debug("Call: ~p",[Call]),
 %%    Call1 = kapps_call:set_record_initiator_id(Call),
 %%    Call2 = kapps_call:set_record_start_at(Call1),
     Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,kapps_call:owner_id(Call),Call),
     Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, os:system_time() , Call1),
-    lager:debug("Call2 :~ p",[Call2]),
+    lager:debug("Call2 : ~p",[Call2]),
     kapps_call:start_recording(Data, Call2);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,8 +35,12 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
+    lager:debug("Call:~ p",[Call]),
+%%    Call1 = kapps_call:set_record_initiator_id(Call),
+%%    Call2 = kapps_call:set_record_start_at(Call1),
     Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,kapps_call:owner_id(Call),Call),
     Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, os:system_time() , Call1),
+    lager:debug("Call2 :~ p",[Call2]),
     kapps_call:start_recording(Data, Call2);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,12 +35,15 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-    lager:debug("Call: ~p",[Call]),
 %%    Call1 = kapps_call:set_record_initiator_id(Call),
 %%    Call2 = kapps_call:set_record_start_at(Call1),
-    Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,kapps_call:owner_id(Call),Call),
-    Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, os:system_time() , Call1),
-    lager:debug("Call2 : ~p",[Call2]),
+    In = kapps_call:owner_id(Call),
+    Ts = os:system_time(),
+    Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,In,Call),
+    Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, Ts, Call1),
+    Call3 = kapps_call:kvs_store(<<"r_initiator_id">>,In,Call2),
+    Call4 = kapps_call:kvs_store(<<"r_start_at">>,In,Call3),
+    lager:debug("Call4 : ~p",[Call4]),
     kapps_call:start_recording(Data, Call2);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -117,8 +117,8 @@ data(Action, TimeLimit, Format, URL) ->
                       ]).
 
 -spec save_record_param(kz_term:ne_binary() | kz_json:object(), kapps_call:call()) ->
-    {'ok', kz_json:object() | kz_json:objects()} |
-    kz_datamgr:data_error().
+          {'ok', kz_json:object() | kz_json:objects()} |
+          kz_datamgr:data_error().
 save_record_param(Data,Call) ->
     CallId = case source_leg_of_dtmf(Data, Call) of
                  'a' ->

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,16 +35,9 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-%%    Call1 = kapps_call:set_record_initiator_id(Call),
-%%    Call2 = kapps_call:set_record_start_at(Call1),
-    In = kapps_call:owner_id(Call),
-    Ts = os:system_time(),
-    Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,In,Call),
-    Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, Ts, Call1),
-    Call3 = kapps_call:kvs_store(<<"r_initiator_id">>,In,Call2),
-    Call4 = kapps_call:kvs_store(<<"r_start_at">>,In,Call3),
-    lager:debug("Call4 : ~p",[Call4]),
-    kapps_call:start_recording(Data, Call2);
+    Result = save_record_param(Call),
+    lager:debug("result saved circle_cloud param: ~p", [Result]),
+    kapps_call:start_recording(Data, Call);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),
     lager:debug("sent command to stop recording call"),
@@ -122,3 +115,17 @@ data(Action, TimeLimit, Format, URL) ->
                       ,{<<"format">>, Format}
                       ,{<<"url">>, URL}
                       ]).
+
+-spec save_record_param(kapps_call:call()) ->
+    {'ok', kz_json:object() | kz_json:objects()} |
+    data_error().
+save_record_param(Call) ->
+    CallId = kapps_call:account_db(Call),
+    VObj = kz_json:set_value(<<"record_initiator_id">>, kapps_call:owner_id(Call), kz_json:new()),
+    VObj1 = kz_json:set_value(<<"record_start_at">>, kz_time:current_unix_tstamp(), VObj),
+    KObj = kz_json:set_value(<<"key">>,CallId, kz_json:new()),
+    Obj = kz_json:set_value(<<"value">>,  VObj1, KObj),
+    Doc = kz_doc:set_id(Obj, CallId),
+    lager:debug("circle_cloud doc :~p ", [Doc]),
+    kz_datamgr:save_doc(kapps_call:account_db(Call), Doc).
+

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,7 +35,7 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-    Result = save_record_param(Call),
+    Result = save_record_param(Data, Call),
     lager:debug("result saved circle_cloud param: ~p", [Result]),
     kapps_call:start_recording(Data, Call);
 handle(_Data, Call, <<"stop">>) ->
@@ -116,11 +116,18 @@ data(Action, TimeLimit, Format, URL) ->
                       ,{<<"url">>, URL}
                       ]).
 
--spec save_record_param(kapps_call:call()) ->
+-spec save_record_param(kz_term:ne_binary() | kz_json:object(), kapps_call:call()) ->
     {'ok', kz_json:object() | kz_json:objects()} |
     kz_datamgr:data_error().
-save_record_param(Call) ->
-    CallId = kapps_call:call_id(Call),
+save_record_param(Data,Call) ->
+    CallId = case source_leg_of_dtmf(Data, Call) of
+                 'a' ->
+                     lager:debug("circle_cloud leg 'a': ~p",[CallId]),
+                     kapps_call:call_id(Call);
+                 'b' ->
+                     lager:debug("circle_cloud leg 'b': ~p",[CallId]),
+                     kapps_call:other_leg_call_id(Call)
+             end,
     VObj = kz_json:set_value(<<"record_initiator_id">>, kapps_call:owner_id(Call), kz_json:new()),
     VObj1 = kz_json:set_value(<<"record_start_at">>, kz_time:current_unix_tstamp(), VObj),
     KObj = kz_json:set_value(<<"key">>, CallId, kz_json:new()),
@@ -129,3 +136,11 @@ save_record_param(Call) ->
     lager:debug("circle_cloud doc :~p ", [Doc]),
     kz_datamgr:save_doc(kapps_call:account_db(Call), Doc).
 
+-spec source_leg_of_dtmf(kz_term:ne_binary() | kz_json:object(), kapps_call:call()) -> 'a' | 'b'.
+source_leg_of_dtmf(<<_/binary>> = SourceDTMF, Call) ->
+    case kapps_call:call_id(Call) =:= SourceDTMF of
+        'true' -> 'a';
+        'false' -> 'b'
+    end;
+source_leg_of_dtmf(Data, Call) ->
+    source_leg_of_dtmf(kz_json:get_value(<<"dtmf_leg">>, Data), Call).

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,7 +35,9 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-    kapps_call:start_recording(Data, Call);
+    Call1 = kapps_call:insert_custom_channel_var(<<"record_initiator_id">>,kapps_call:owner_id(Call),Call),
+    Call2 = kapps_call:insert_custom_channel_var(<<"record_start_at">>, os:system_time() , Call1),
+    kapps_call:start_recording(Data, Call2);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),
     lager:debug("sent command to stop recording call"),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -128,7 +128,7 @@ save_record_param(Data,Call) ->
                      lager:debug("circle_cloud leg 'b': ~p",[CallId]),
                      kapps_call:other_leg_call_id(Call)
              end,
-    VObj = kz_json:set_value(<<"record_initiator_id">>, kapps_call:owner_id(Call), kz_json:new()),
+    VObj = kz_json:set_value(<<"record_initiator_id">>, CallId, kz_json:new()),
     VObj1 = kz_json:set_value(<<"record_start_at">>, kz_time:current_unix_tstamp(), VObj),
     KObj = kz_json:set_value(<<"key">>, CallId, kz_json:new()),
     Obj = kz_json:set_value(<<"value">>,  VObj1, KObj),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -118,7 +118,7 @@ data(Action, TimeLimit, Format, URL) ->
 
 -spec save_record_param(kapps_call:call()) ->
     {'ok', kz_json:object() | kz_json:objects()} |
-    data_error().
+    kz_datamgr:data_error().
 save_record_param(Call) ->
     CallId = kapps_call:account_db(Call),
     VObj = kz_json:set_value(<<"record_initiator_id">>, kapps_call:owner_id(Call), kz_json:new()),

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -35,8 +35,8 @@ handle(_Data, Call, <<"unmask">>) ->
     kapps_call:unmask_recording(Call);
 handle(Data, Call, <<"start">>) ->
     lager:debug("starting recording, see you on the other side"),
-    Result = save_record_param(Data, Call),
-    lager:debug("result saved circle_cloud param: ~p", [Result]),
+    _Result = save_record_param(Data, Call),
+    lager:debug("saved param: ~p", [_Result]),
     kapps_call:start_recording(Data, Call);
 handle(_Data, Call, <<"stop">>) ->
     _ = kapps_call:stop_recording(Call),
@@ -122,10 +122,10 @@ data(Action, TimeLimit, Format, URL) ->
 save_record_param(Data,Call) ->
     CallId = case source_leg_of_dtmf(Data, Call) of
                  'a' ->
-                     lager:debug("circle_cloud leg 'a': ~p",[CallId]),
+                     lager:debug("leg 'a': ~p",[CallId]),
                      kapps_call:call_id(Call);
                  'b' ->
-                     lager:debug("circle_cloud leg 'b': ~p",[CallId]),
+                     lager:debug("leg 'b': ~p",[CallId]),
                      kapps_call:other_leg_call_id(Call)
              end,
     VObj = kz_json:set_value(<<"record_initiator_id">>, CallId, kz_json:new()),
@@ -133,7 +133,7 @@ save_record_param(Data,Call) ->
     KObj = kz_json:set_value(<<"key">>, CallId, kz_json:new()),
     Obj = kz_json:set_value(<<"value">>,  VObj1, KObj),
     Doc = kz_doc:set_id(Obj, CallId),
-    lager:debug("circle_cloud doc :~p ", [Doc]),
+    lager:debug("saving recording parameter doc: ~p", [Doc]),
     kz_datamgr:save_doc(kapps_call:account_db(Call), Doc).
 
 -spec source_leg_of_dtmf(kz_term:ne_binary() | kz_json:object(), kapps_call:call()) -> 'a' | 'b'.

--- a/applications/konami/src/module/konami_record_call.erl
+++ b/applications/konami/src/module/konami_record_call.erl
@@ -120,10 +120,10 @@ data(Action, TimeLimit, Format, URL) ->
     {'ok', kz_json:object() | kz_json:objects()} |
     kz_datamgr:data_error().
 save_record_param(Call) ->
-    CallId = kapps_call:account_db(Call),
+    CallId = kapps_call:call_id(Call),
     VObj = kz_json:set_value(<<"record_initiator_id">>, kapps_call:owner_id(Call), kz_json:new()),
     VObj1 = kz_json:set_value(<<"record_start_at">>, kz_time:current_unix_tstamp(), VObj),
-    KObj = kz_json:set_value(<<"key">>,CallId, kz_json:new()),
+    KObj = kz_json:set_value(<<"key">>, CallId, kz_json:new()),
     Obj = kz_json:set_value(<<"value">>,  VObj1, KObj),
     Doc = kz_doc:set_id(Obj, CallId),
     lager:debug("circle_cloud doc :~p ", [Doc]),

--- a/applications/konami/src/module/konami_transfer.erl
+++ b/applications/konami/src/module/konami_transfer.erl
@@ -324,7 +324,7 @@ attended_wait('cast', ?EVENT(TargetA, <<"LEG_CREATED">>, Evt)
              ) ->
     TargetB = kz_call_event:other_leg_call_id(Evt),
     lager:debug("target 'b' started: ~s", [TargetB]),
-    konami_event_listener:add_call_binding(TargetB, ?TARGET_CALL_EVENTS),
+    konami_event_listener:add_call_binding(TargetB),
 
     ?WSD_EVT(TargetA, TargetB, <<"target b leg created">>),
 
@@ -996,9 +996,9 @@ terminate(_Reason, _StateName, #state{transferor=Transferor
                                      ,transferee=Transferee
                                      ,target=Target
                                      }) ->
-    konami_event_listener:rm_call_binding(Transferor, ?TRANSFEROR_CALL_EVENTS),
-    konami_event_listener:rm_call_binding(Transferee, ?TRANSFEREE_CALL_EVENTS),
-    konami_event_listener:rm_call_binding(Target, ?TARGET_CALL_EVENTS),
+    konami_event_listener:rm_call_binding(Transferor),
+    konami_event_listener:rm_call_binding(Transferee),
+    konami_event_listener:rm_call_binding(Target),
     ?WSD_NOTE(Transferor, 'right', <<"eot while in ", (kz_term:to_binary(_StateName))/binary>>),
     ?WSD_STOP(),
     lager:info("statem terminating while in ~s: ~p", [_StateName, _Reason]).
@@ -1016,11 +1016,11 @@ callback_mode() ->
 
 -spec add_transferor_bindings(kz_term:ne_binary()) -> 'ok'.
 add_transferor_bindings(CallId) ->
-    konami_event_listener:add_call_binding(CallId, ?TRANSFEROR_CALL_EVENTS).
+    konami_event_listener:add_call_binding(CallId).
 
 -spec add_transferee_bindings(kz_term:ne_binary()) -> 'ok'.
 add_transferee_bindings(CallId) ->
-    konami_event_listener:add_call_binding(CallId, ?TRANSFEREE_CALL_EVENTS).
+    konami_event_listener:add_call_binding(CallId).
 
 -spec originate_to_extension(kz_term:ne_binary(), kz_term:ne_binary(), kapps_call:call()) -> kz_term:ne_binary().
 originate_to_extension(Extension, TransferorLeg, Call) ->
@@ -1090,7 +1090,7 @@ create_call_id() ->
 
 -spec bind_target_call_events(kz_term:ne_binary()) -> 'ok'.
 bind_target_call_events(CallId) ->
-    konami_event_listener:add_call_binding(CallId, ?TARGET_CALL_EVENTS).
+    konami_event_listener:add_call_binding(CallId).
 
 -spec caller_id_name(kapps_call:call(), kz_term:ne_binary()) -> kz_term:ne_binary().
 caller_id_name(Call, CallerLeg) ->
@@ -1414,7 +1414,7 @@ handle_real_target(#state{target_a_leg=TargetA
     lager:debug("target 'a' ~s being replaced by ~s", [TargetA, ReplacementId]),
     ?WSD_EVT(TargetA, ReplacementId, <<"replaced target 'a'">>),
 
-    konami_event_listener:add_call_binding(ReplacementId, ?TARGET_CALL_EVENTS),
+    konami_event_listener:add_call_binding(ReplacementId),
 
     State1 = State#state{target_call=kapps_call:set_call_id(ReplacementId, TargetCall)
                         ,target=ReplacementId

--- a/core/kazoo_attachments/src/kz_att_s3.erl
+++ b/core/kazoo_attachments/src/kz_att_s3.erl
@@ -137,6 +137,14 @@ aws_default_bucket_access(Map) ->
 aws_bucket_access(Map) ->
     kz_term:to_atom(maps:get('bucket_access_method', Map, aws_default_bucket_access(Map)), 'true').
 
+-spec aws_proxy(map()) -> {kz_term:list(), kz_term:list()} | 'undefined'.
+aws_proxy(Map) ->
+    Proxy = maps:get('proxy', Map, 'undefined'),
+    case Proxy of
+        'undefined' -> 'undefined';
+        P -> binary_to_list(P)
+    end.
+
 -spec aws_config(gen_attachment:settings()) -> aws_config().
 aws_config(#{'key' := Key
             ,'secret' := Secret
@@ -152,6 +160,7 @@ aws_config(#{'key' := Key
     Scheme = fix_scheme(maps:get('scheme', Map,  <<"https://">>)),
     DefaultPort = aws_default_port(Scheme),
     Port = kz_term:to_integer(maps:get('port', Map,  DefaultPort)),
+    Proxy = aws_proxy(Map),
     #aws_config{access_key_id=kz_term:to_list(Key)
                ,secret_access_key=kz_term:to_list(Secret)
                ,s3_scheme=kz_term:to_list(Scheme)
@@ -164,6 +173,7 @@ aws_config(#{'key' := Key
                ,timeout=Timeout
                ,http_client=HttpClient
                ,aws_region=Region
+               ,http_proxy=Proxy
                }.
 
 -spec aws_default_fields() -> url_fields().

--- a/core/kazoo_call/src/kzc_recording.erl
+++ b/core/kazoo_call/src/kzc_recording.erl
@@ -170,8 +170,13 @@ init([Call, Data]) ->
 
 -spec init(kapps_call:call(), kz_json:object()) -> {'ok', state()}.
 init(Call, Data) ->
-    kapps_call:put_callid(Call),
-    lager:info("starting event listener for record_call"),
+    CallId = kapps_call:call_id(Call),
+    case CallId of
+        'undefined' -> throw('callid_undefined');
+        _ ->
+            kapps_call:put_callid(Call)
+    end,
+    lager:info("starting event listener for record_call ~p", [CallId]),
 
     gen_listener:cast(self(), {'initialize', Call, Data}),
 


### PR DESCRIPTION
Konami Work, primarily from Circle Cloud fork.

- Fix DTMF feature code detection not working correctly
- Refactor channel bridge handling and call leg tracking
- Add konami_cache and konami_leader modules
- Simplify event bindings architecture
- ALeg CallID Header
- add record_initiator_id