### PR TITLE
applications/ecallmgr: fix bug in network_map and add documentation

### DIFF
--- a/applications/crossbar/priv/api/descriptions.system_config.json
+++ b/applications/crossbar/priv/api/descriptions.system_config.json
@@ -282,7 +282,7 @@
     "ecallmgr.max_channel_uptime_s": "ecallmgr maximum channel uptime in seconds",
     "ecallmgr.max_timeout_for_node_restart": "ecallmgr maximum timeout for node restart",
     "ecallmgr.modules": "ecallmgr modules",
-    "ecallmgr.network_map": "ecallmgr network map",
+    "ecallmgr.network_map": "allows specification of custom SIP profiles to use for specific destination network ranges",
     "ecallmgr.node_down_grace_period": "ecallmgr node down grace period",
     "ecallmgr.process_gateways": "ecallmgr process gateways",
     "ecallmgr.publish_channel_reconnect": "ecallmgr publish channel reconnect",

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -31797,7 +31797,19 @@
                 },
                 "network_map": {
                     "default": {},
-                    "description": "ecallmgr network map",
+                    "description": "allows specification of custom SIP profiles to use for specific destination network ranges",
+                    "patternProperties": {
+                        "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(3[0-2]|[1-2]?[0-9]))$": {
+                            "description": "a CIDR IP network, e.g. '172.16.4.0/24'",
+                            "properties": {
+                                "custom_sip_interface": {
+                                    "description": "the freeswitch sip profile to use for this network",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
                     "type": "object"
                 },
                 "node_commands": {

--- a/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
+++ b/applications/crossbar/priv/couchdb/schemas/system_config.ecallmgr.json
@@ -285,7 +285,19 @@
         },
         "network_map": {
             "default": {},
-            "description": "ecallmgr network map",
+            "description": "allows specification of custom SIP profiles to use for specific destination network ranges",
+            "patternProperties": {
+                "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(3[0-2]|[1-2]?[0-9]))$": {
+                    "description": "a CIDR IP network, e.g. '172.16.4.0/24'",
+                    "properties": {
+                        "custom_sip_interface": {
+                            "description": "the freeswitch sip profile to use for this network",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
             "type": "object"
         },
         "node_commands": {

--- a/applications/ecallmgr/doc/config.md
+++ b/applications/ecallmgr/doc/config.md
@@ -47,7 +47,7 @@ Key | Description | Type | Default | Required | Support Level
 `max_channel_uptime_s` | ecallmgr maximum channel uptime in seconds | `integer()` | `0` | `false` |
 `max_timeout_for_node_restart` | ecallmgr maximum timeout for node restart | `integer()` | `10000` | `false` |
 `multivar_separator` | ecallmgr multivar_separator | `string()` | `~` | `false` |
-`network_map` | ecallmgr network map | `object()` | `{}` | `false` |
+`network_map` | allows specification of custom SIP profiles to use for specific destination network ranges | `object()` | `{}` | `false` |
 `node_commands` |   |   |   | `false` |
 `node_down_grace_period` | ecallmgr node down grace period | `integer()` | `10000` | `false` |
 `process_gateways` | ecallmgr process gateways | `boolean()` | `false` | `false` |
@@ -95,3 +95,14 @@ This means that if any SIP device from the resulting endpoint list has an active
 ### "Normal" call forwarded endpoints
 
 If a user or ring group has "normal" call-forwarded endpoints included, since these endpoints don't maintain a registration (since they typically are forwarded to another DID), then they aren't ever "offline" from KAZOO's perspective. Bear this in mind when failover endpoints aren't ringing when SIP endpoints are unregistered.
+
+### `network_map` usage
+
+The `network_map` object can contain one or more objects specifying a custom SIP profile for Freeswitch to use when `fs_path` is found on the contact header. Example:
+``` json
+"network_map": {
+  "172.16.75.0/24": {
+    "custom_sip_interface": "my_custom_sip_profile"
+  }
+}
+```

--- a/applications/ecallmgr/src/ecallmgr_util.erl
+++ b/applications/ecallmgr/src/ecallmgr_util.erl
@@ -1263,7 +1263,7 @@ maybe_set_interface(<<"sofia/", _/binary>>=Contact, _) -> Contact;
 maybe_set_interface(<<"loopback/", _/binary>>=Contact, _) -> Contact;
 maybe_set_interface(Contact, #bridge_endpoint{sip_interface='undefined'}=Endpoint) ->
     Options = ['ungreedy', {'capture', 'all_but_first', 'binary'}],
-    case re:run(Contact, <<";fs_path=sip:(.*):\\d*;">>, Options) of
+    case re:run(Contact, <<";fs_path=sip:(.*):\\d*;?">>, Options) of
         {'match', FsPath} ->
             SIPInterface = kz_term:to_binary(get_sip_interface_from_db(FsPath)),
             maybe_set_interface(Contact, Endpoint#bridge_endpoint{sip_interface=SIPInterface});


### PR DESCRIPTION
There was a bug in the functionality of `system_config/ecallmgr.network_map` where it was only actually checked if there were additional SIP invite parameters after fs_path, since a trailing semicolon was a required part of the regex match. Adding a question mark after the semicolon fixes that and allows network_map to be queried as it should.