### PR TITLE
openkazoo: update remaining deprecated log_stacktrace/0 calls

### DIFF
--- a/applications/teletype/test/teletype_publish_tests.erl
+++ b/applications/teletype/test/teletype_publish_tests.erl
@@ -98,9 +98,9 @@ kz_amqp_worker_call_collect() ->
             try PublishFun(Req) of
                 ok -> wait_collect_until(UntilFun, [], erlang:start_timer(Timeout, self(), req_timeout))
             catch
-                _E:T ->
+                _E:T:ST ->
                     ?LOG_DEBUG("failed to publish: ~p:~p", [_E, T]),
-                    kz_util:log_stacktrace(),
+                    kz_util:log_stacktrace(ST),
                     {error, T}
             end
     end.

--- a/core/kazoo_amqp/src/api/kapi_dialplan.erl
+++ b/core/kazoo_amqp/src/api/kapi_dialplan.erl
@@ -1144,7 +1144,7 @@ build_command(Prop, DPApp) when is_list(Prop) ->
                     ?MODULE:BuildMsgFun(kz_api:set_missing_values(Prop, ?DEFAULT_VALUES))
             end
     catch
-        _:R -> kz_util:log_stacktrace(),
+        _:R:ST -> kz_util:log_stacktrace(ST),
                throw({R, Prop})
     end;
 build_command(JObj, DPApp) ->

--- a/core/kazoo_amqp/src/api/kapi_dialplan.erl
+++ b/core/kazoo_amqp/src/api/kapi_dialplan.erl
@@ -1145,7 +1145,7 @@ build_command(Prop, DPApp) when is_list(Prop) ->
             end
     catch
         _:R:ST -> kz_util:log_stacktrace(ST),
-               throw({R, Prop})
+                  throw({R, Prop})
     end;
 build_command(JObj, DPApp) ->
     build_command(kz_json:to_proplist(JObj), DPApp).

--- a/core/kazoo_amqp/src/api/kapi_globals.erl
+++ b/core/kazoo_amqp/src/api/kapi_globals.erl
@@ -70,9 +70,8 @@ maybe_decode(MaybeEncoded) ->
         Decoded ->
             binary_to_term(Decoded)
     catch
-        'error':'function_clause' -> MaybeEncoded;
-        'error':{'badmatch','false'} -> MaybeEncoded;
-        'error':{'badarg', _} -> MaybeEncoded
+        _E:_R:_ST -> lager:debug("binary is not base64"),
+                     MaybeEncoded
     end.
 
 -spec encode_req(kz_json:object() | kz_term:proplist()) -> any().

--- a/core/kazoo_apps/src/kz_amqp_worker.erl
+++ b/core/kazoo_apps/src/kz_amqp_worker.erl
@@ -535,9 +535,9 @@ send_request(CallId, Self, PublishFun, ReqProps)
     try PublishFun(Props) of
         'ok' -> 'ok'
     catch
-        _R:E ->
+        _R:E:ST ->
             lager:debug("failed to publish: ~s: ~p", [_R, E]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             {'error', E}
     end.
 

--- a/core/kazoo_auth/src/kz_auth.erl
+++ b/core/kazoo_auth/src/kz_auth.erl
@@ -191,9 +191,9 @@ authenticate_fold(Token, [Fun | Routines]) ->
     try Fun(Token) of
         NewToken -> authenticate_fold(NewToken, Routines)
     catch
-        _E:_R ->
+        _E:_R:ST ->
             lager:debug("exception executing ~p : ~p , ~p", [Fun, _E, _R]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             authenticate_fold(Token, Routines)
     end.
 

--- a/core/kazoo_auth/src/kz_auth_profile.erl
+++ b/core/kazoo_auth/src/kz_auth_profile.erl
@@ -71,9 +71,9 @@ token_fold(Token, [Fun | Routines]) ->
     try Fun(Token) of
         NewToken -> token_fold(NewToken, Routines)
     catch
-        _E:_R ->
+        _E:_R:ST ->
             lager:debug("exception executing ~p : ~p , ~p", [Fun, _E, _R]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             token_fold(Token, Routines)
     end.
 

--- a/core/kazoo_auth/src/kz_auth_util.erl
+++ b/core/kazoo_auth/src/kz_auth_util.erl
@@ -95,8 +95,8 @@ run(Token, [Fun | Routines]) ->
         {'error', Error} -> {'error', Token#{error => Error}};
         NewToken -> run(NewToken, Routines)
     catch
-        _E:_R ->
+        _E:_R:ST ->
             lager:debug("exception executing ~p : ~p , ~p, ~p", [Fun, _E, _R, Token]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             {'error', Token}
     end.

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -756,7 +756,6 @@ maybe_missing_resource_type(_Endpoint, _Properties, Call) ->
           {'error', 'no_resource_type'}.
 maybe_missing_resource_type('undefined') ->
     lager:error("kapps_call resource type is undefined"),
-    kz_util:log_stacktrace(),
     {'error', 'no_resource_type'};
 maybe_missing_resource_type(_) -> 'ok'.
 

--- a/core/kazoo_endpoint/src/kz_endpoint.erl
+++ b/core/kazoo_endpoint/src/kz_endpoint.erl
@@ -951,9 +951,9 @@ try_create_endpoint(Routine, Endpoints, Endpoint, Properties, Call) when is_func
             lager:debug("created endpoint ~s", [kz_doc:id(JObj)]),
             [JObj|Endpoints]
     catch
-        _E:_R ->
+        _E:_R:ST ->
             lager:warning("unable to build endpoint(~s): ~p", [_E, _R]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             Endpoints
     end.
 

--- a/core/kazoo_globals/src/kz_nodes.erl
+++ b/core/kazoo_globals/src/kz_nodes.erl
@@ -840,9 +840,9 @@ handle_info({'heartbeat', Ref}
         'exit' : {'timeout' , _} ->
             lager:warning("timeout creating node, no data to send"),
             {'noreply', State#state{heartbeat_ref=Reference}};
-        _E:_N ->
+        _E:_N:ST ->
             lager:error("error creating node ~p : ~p", [_E, _N]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             {'noreply', State#state{heartbeat_ref=Reference}, 'hibernate'}
     end;
 

--- a/core/kazoo_media/src/kz_media_proxy_handler.erl
+++ b/core/kazoo_media/src/kz_media_proxy_handler.erl
@@ -65,8 +65,8 @@ init_from_doc(Url, Req, StreamType) ->
                     {'ok', Req1, 'ok'}
             end
     catch
-        _E:_R ->
-            kz_util:log_stacktrace(),
+        _E:_R:ST ->
+            kz_util:log_stacktrace(ST),
             lager:debug("exception thrown: ~s: ~p", [_E, _R]),
             Req1 = cowboy_req:reply(404, Req),
             {'ok', Req1, 'ok'}

--- a/core/kazoo_number_manager/src/carriers/knm_carriers.erl
+++ b/core/kazoo_number_manager/src/carriers/knm_carriers.erl
@@ -104,8 +104,8 @@ check_numbers(Module, Nums) ->
         {'ok', JObj} -> {kz_json:to_map(JObj), #{}};
         {error, _} -> {#{}, maps:from_list([{Num,<<"error">>} || Num <- Nums])}
     catch
-        _:_ ->
-            kz_util:log_stacktrace(),
+        _:_:ST ->
+            kz_util:log_stacktrace(ST),
             {#{}, maps:from_list([{Num,<<"error">>} || Num <- Nums])}
     end.
 
@@ -204,8 +204,8 @@ info_fold(Module, Info=#{?CARRIER_INFO_MAX_PREFIX := MaxPrefix}) ->
             Info#{?CARRIER_INFO_MAX_PREFIX => Lower};
         _ -> Info
     catch
-        _E:_R ->
-            kz_util:log_stacktrace(),
+        _E:_R:ST ->
+            kz_util:log_stacktrace(ST),
             Info
     end.
 
@@ -352,8 +352,8 @@ is_number_billable(PhoneNumber) ->
 is_local(Carrier) ->
     try apply(Carrier, 'is_local', [])
     catch
-        _E:_R ->
-            kz_util:log_stacktrace(),
+        _E:_R:ST ->
+            kz_util:log_stacktrace(ST),
             'true'
     end.
 

--- a/core/kazoo_number_manager/src/knm_phone_number.erl
+++ b/core/kazoo_number_manager/src/knm_phone_number.erl
@@ -874,8 +874,8 @@ setters_pn(PN, Routines) ->
             ?LOG_ERROR("~s failed, argument: ~p", [FName, Arg]),
             kz_util:log_stacktrace(ST),
             {'error', FName};
-        'error':Reason ->
-            kz_util:log_stacktrace(),
+        'error':Reason:ST ->
+            kz_util:log_stacktrace(ST),
             {'error', Reason}
     end.
 

--- a/core/kazoo_proper/src/pqc_cb_port_requests.erl
+++ b/core/kazoo_proper/src/pqc_cb_port_requests.erl
@@ -108,9 +108,9 @@ initial_state() ->
                    ,lists:reverse(?ACCOUNT_NAMES)
                    )
     catch
-        _R:_T ->
+        _R:_T:ST ->
             ?debugFmt("exception ~p:~p", [_R, _T]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             cleanup(State),
             throw(failed)
     end.

--- a/core/kazoo_translator/src/converters/kzt_twiml.erl
+++ b/core/kazoo_translator/src/converters/kzt_twiml.erl
@@ -62,9 +62,9 @@ exec_elements(Call, [El|Els]) ->
         'throw':{'unknown_element', Name} ->
             lager:error("unknown element in response: ~s", [Name]),
             {'error', kzt_util:add_error(Call, <<"unknown_element">>, Name)};
-        _E:_R ->
+        _E:_R:ST ->
             lager:error("'~s' when execing el ~p: ~p", [_E, El, _R]),
-            kz_util:log_stacktrace(),
+            kz_util:log_stacktrace(ST),
             {'error', Call}
     end.
 

--- a/rebar.config
+++ b/rebar.config
@@ -171,4 +171,4 @@
            ,{prod, [{erl_opts, [no_debug_info, warnings_as_errors]}]}
            ]}.
 
-{minimum_otp_vsn, "27"}.
+{minimum_otp_vsn, "26"}.


### PR DESCRIPTION
- updated several calls to `kz_util:log_stacktrace/0` which had not been updated to use `kz_util:log_stacktrace/1`
- fixed bug in `kapi_globals` where error case from `base64:maybe_decode` was unhandled
- lowered minimum Erlang version in rebar.config to 26, since there is no code that is specific to Erlang 27, and v26 is the default installed version in RHEL9 distros. 
