### PR TITLE
applications/conference: add dtmf feature to conferences

### DIFF
--- a/applications/crossbar/doc/conference.md
+++ b/applications/crossbar/doc/conference.md
@@ -349,6 +349,18 @@ Playing a media file to everyone in a conference:
 
 `{MEDIA_ID}` can be a pre-uploaded media ID or a URL to fetch media from.
 
+### Sending DTMF to a conference
+
+Sending DTMF tones to everyone in a conference:
+
+```json
+{"data":{
+    "action":"dtmf",
+    "data":{"digits":"{DTMF DIGITS [0-9,A-D,*,#]}"}
+ }
+}
+```
+
 ## Perform an action on participants
 
 > PUT /v2/accounts/{ACCOUNT_ID}/conferences/{CONFERENCE_ID}/participants
@@ -440,6 +452,7 @@ curl -v -X PUT \
  `undeaf` | Start sending conference audio to the participant
  `kick` | Kick the participant from the conference
  `play` | Play media to a single participant
+ `dtmf` | Send DTMF tones to a single participant
 
 ### Playing media to a conference
 
@@ -454,6 +467,18 @@ Playing a media file to everyone in a conference:
 ```
 
 `{MEDIA_ID}` can be a pare-uploaded media ID or a URL to fetch media from.
+
+### Sending DTMF tones to a conference participant
+
+Sending DTMF to a participant in a conference:
+
+```json
+{"data":{
+    "action":"dtmf",
+    "data":{"digits":"{DTMF DIGITS [0-9,A-D,*,#]}"}
+ }
+}
+```
 
 ### List of conferences example
 

--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -11041,6 +11041,47 @@
             ],
             "type": "object"
         },
+        "kapi.conference.dtmf": {
+            "description": "AMQP API for conference.dtmf",
+            "properties": {
+                "Application-Name": {
+                    "enum": [
+                        "dtmf"
+                    ],
+                    "type": "string"
+                },
+                "Conference-ID": {
+                    "type": "string"
+                },
+                "Digits": {
+                    "type": [
+                        "number",
+                        "string"
+                    ]
+                },
+                "Event-Category": {
+                    "enum": [
+                        "conference"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "command"
+                    ],
+                    "type": "string"
+                },
+                "Participant-ID": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Application-Name",
+                "Conference-ID",
+                "Digits"
+            ],
+            "type": "object"
+        },
         "kapi.conference.event": {
             "description": "AMQP API for conference.event",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.conference.dtmf.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.conference.dtmf.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.conference.dtmf",
+    "description": "AMQP API for conference.dtmf",
+    "properties": {
+        "Application-Name": {
+            "enum": [
+                "dtmf"
+            ],
+            "type": "string"
+        },
+        "Conference-ID": {
+            "type": "string"
+        },
+        "Digits": {
+            "type": [
+                "number",
+                "string"
+            ]
+        },
+        "Event-Category": {
+            "enum": [
+                "conference"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "command"
+            ],
+            "type": "string"
+        },
+        "Participant-ID": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Application-Name",
+        "Conference-ID",
+        "Digits"
+    ],
+    "type": "object"
+}

--- a/applications/crossbar/src/modules/cb_conferences.erl
+++ b/applications/crossbar/src/modules/cb_conferences.erl
@@ -1,5 +1,5 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc Conferences module
 %%% Handle client requests for conference documents
 %%%
@@ -9,10 +9,10 @@
 %%% /v2/accounts/{AccountId}/conferences/{ConferenceID}/participants
 %%% /v2/accounts/{AccountId}/conferences/{ConferenceID}/participants/{ParticipantId}
 %%%
-%%%
 %%% @author Karl Anderson
 %%% @author James Aimonetti
 %%% @author Roman Galeev
+%%% @author Ruel Tmeizeh for Umojo, Inc.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(cb_conferences).
@@ -46,6 +46,7 @@
 -define(KICK, <<"kick">>).
 -define(RELATE, <<"relate">>).
 -define(PLAY, <<"play">>).
+-define(DTMF, <<"dtmf">>).
 
 -define(PUT_ACTION, <<"action">>).
 
@@ -222,6 +223,9 @@ put(Context, ConferenceId, ?PARTICIPANTS, ParticipantId) ->
 participant_action(Context, ConferenceId, ParticipantId, ?PLAY) ->
     play(Context, ConferenceId, ParticipantId, cb_context:req_value(Context, <<"data">>));
 
+participant_action(Context, ConferenceId, ParticipantId, ?DTMF) ->
+    dtmf(Context, ConferenceId, ParticipantId, cb_context:req_value(Context, <<"data">>));
+
 participant_action(Context, ConferenceId, ParticipantId, Action) ->
     perform_participant_action(conference(ConferenceId), Action, kz_term:to_integer(ParticipantId)),
     crossbar_util:response_202(<<"ok">>, Context).
@@ -374,6 +378,8 @@ handle_conference_action(Context, ConferenceId, <<"unlock">>) ->
     crossbar_util:response_202(<<"ok">>, Context);
 handle_conference_action(Context, ConferenceId, ?PLAY) ->
     play(Context, ConferenceId, cb_context:req_value(Context, <<"data">>));
+handle_conference_action(Context, ConferenceId, ?DTMF) ->
+    dtmf(Context, ConferenceId, cb_context:req_value(Context, <<"data">>));
 handle_conference_action(Context, ConferenceId, <<"dial">>) ->
     dial(Context, ConferenceId, cb_context:req_value(Context, <<"data">>));
 handle_conference_action(Context, ConferenceId, Action) ->
@@ -439,6 +445,43 @@ media_id_required(Context) ->
     cb_context:add_validation_error([<<"data">>, <<"media_id">>]
                                    ,<<"required">>
                                    ,kz_json:from_list([{<<"message">>, <<"action 'play' requires a media ID or URL">>}])
+                                   ,Context
+                                   ).
+
+%% send DTMF to all participants in conference (ParticipantId undefined)
+-spec dtmf(cb_context:context(), path_token(), kz_term:api_object()) -> cb_context:context().
+dtmf(Context, _ConferenceId, 'undefined') ->
+    data_required(Context, <<"dtmf">>);
+dtmf(Context, ConferenceId, Data) ->
+    dtmf(Context, ConferenceId, 'undefined', Data).
+
+-spec dtmf(cb_context:context(), path_token(), pos_integer(), kz_term:api_object()) -> cb_context:context().
+dtmf(Context, _ConferenceId, _ParticipantId, 'undefined') ->
+    data_required(Context, <<"dtmf">>);
+dtmf(Context, ConferenceId, ParticipantId, Data) ->
+    ParticipantMsg =
+        case kz_term:to_api_binary(ParticipantId) of
+            'undefined' -> <<>>;
+            Participant -> <<" participant ", Participant/binary>>
+        end,
+    case dtmf_digits(kz_json:get_value(<<"digits">>, Data)) of
+        <<>> -> digits_required(Context);
+        DTMF ->
+            lager:info("sending DTMF ~s to conference ~s~s", [DTMF, ConferenceId, ParticipantMsg]),
+            kapps_conference_command:dtmf(DTMF, ParticipantId, conference(ConferenceId)),
+            crossbar_util:response_202(<<"ok">>, Context)
+    end.
+
+-spec dtmf_digits(any()) -> binary().
+dtmf_digits('undefined') -> <<>>;
+dtmf_digits(<<>>) -> <<>>;
+dtmf_digits(Digits) -> re:replace(kz_term:to_binary(Digits), "[^a-dA-D0-9*#]", "", [global, {return, binary}]).
+
+-spec digits_required(cb_context:context()) -> cb_context:context().
+digits_required(Context) ->
+    cb_context:add_validation_error([<<"data">>, <<"digits">>]
+                                   ,<<"required">>
+                                   ,kz_json:from_list([{<<"message">>, <<"action 'dtmf' requires digits [0123456789*#ABCD] to be specified">>}])
                                    ,Context
                                    ).
 
@@ -778,6 +821,8 @@ handle_participants_action(Context, ConferenceId, Action=?UNDEAF) ->
 handle_participants_action(Context, ConferenceId, Action=?KICK) ->
     handle_participants_action(Context, ConferenceId, Action, fun kz_term:always_true/1);
 handle_participants_action(Context, ConferenceId, Action=?PLAY) ->
+    handle_conference_action(Context, ConferenceId, Action);
+handle_participants_action(Context, ConferenceId, Action=?DTMF) ->
     handle_conference_action(Context, ConferenceId, Action);
 handle_participants_action(Context, ConferenceId, ?RELATE) ->
     OnSuccess = fun(C) -> handle_participants_relate(C, ConferenceId) end,

--- a/applications/ecallmgr/src/ecallmgr_conference_command.erl
+++ b/applications/ecallmgr/src/ecallmgr_conference_command.erl
@@ -1,6 +1,9 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc Execute conference commands
+%%%
+%%% @author 2600Hz
+%%% @author Ruel Tmeizeh for Umojo, Inc.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(ecallmgr_conference_command).
@@ -138,6 +141,22 @@ get_conf_command(<<"stop_play">>, _Focus, _ConferenceId, JObj) ->
                        Participant -> list_to_binary([Affects, " ", Participant])
                    end,
             {<<"stop">>, Args}
+    end;
+
+get_conf_command(<<"dtmf">>, _Focus, _ConferenceId, JObj) ->
+    case kapi_conference:dtmf_v(JObj) of
+        'false' ->
+            {'error', <<"conference dtmf failed to execute as JObj did not validate.">>};
+        'true' ->
+            DigitsRaw = kz_term:to_binary(kz_json:get_value(<<"Digits">>, JObj)),
+            Digits = re:replace(DigitsRaw, "[^a-dA-D0-9*#]", "", [global, {return, binary}]),
+            Participant =
+                case kz_json:get_ne_binary_value(<<"Participant-ID">>, JObj) of
+                    'undefined' -> <<"all">>;
+                    P -> P
+                end,
+            Args = list_to_binary([Participant, " ", Digits]),
+            {<<"dtmf">>, Args}
     end;
 
 get_conf_command(Say, _Focus, _ConferenceId, JObj)

--- a/core/kazoo_amqp/src/api/kapi_conference.erl
+++ b/core/kazoo_amqp/src/api/kapi_conference.erl
@@ -1,7 +1,8 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2012-2022, 2600Hz
+%%% @copyright (C) 2012-2026, 2600Hz
 %%% @doc
 %%% @author Karl Anderson
+%%% @author Ruel Tmeizeh for Umojo, Inc.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kapi_conference).
@@ -23,6 +24,7 @@
 -export([mute_participant/1, mute_participant_v/1]).
 -export([play/1, play_v/1
         ,tones/1, tones_v/1
+        ,dtmf/1, dtmf_v/1
         ,say/1, say_v/1
         ,tts/1, tts_v/1
         ]).
@@ -304,6 +306,17 @@
                     ,{<<"Media-Name">>, fun is_binary/1}
                     ]).
 
+%% Conference DTMF
+-define(DTMF_HEADERS, [<<"Application-Name">>, <<"Conference-ID">>, <<"Digits">>]).
+-define(OPTIONAL_DTMF_HEADERS, [<<"Participant-ID">>]).
+-define(DTMF_VALUES, [{<<"Event-Category">>, <<"conference">>}
+                     ,{<<"Event-Name">>, <<"command">>}
+                     ,{<<"Application-Name">>, <<"dtmf">>}
+                     ]).
+-define(DTMF_TYPES, [{<<"Conference-ID">>, fun is_binary/1}
+                    ,{<<"Digits">>, fun is_valid_dtmf/1}
+                    ]).
+
 %% Conference Record
 -define(RECORD_HEADERS, [<<"Application-Name">>, <<"Conference-ID">>, <<"Media-Name">>]).
 -define(OPTIONAL_RECORD_HEADERS, [<<"Call-ID">>]).
@@ -562,6 +575,7 @@
                         ,{<<"participant_volume_out">>, ?PARTICIPANT_VOLUME_OUT_VALUES, fun participant_volume_out/1}
                         ,{<<"dial">>, ?DIAL_VALUES, fun dial/1}
                         ,{<<"dial_resp">>, ?DIAL_RESP_VALUES, fun dial_resp/1}
+                        ,{<<"dtmf">>, ?DTMF_VALUES, fun dtmf/1}
                         ,{<<"tones">>, ?CONF_TONES_REQ_VALUES, fun tones/1}
                         ,{<<"say">>, ?CONF_SAY_REQ_VALUES, fun say/1}
                         ,{<<"tts">>, ?CONF_SAY_REQ_VALUES, fun tts/1}
@@ -911,6 +925,32 @@ play_macro_req(JObj) -> play_macro_req(kz_json:to_proplist(JObj)).
 play_macro_req_v(Prop) when is_list(Prop) ->
     kz_api:validate(Prop, ?CONF_PLAY_MACRO_REQ_HEADERS, ?CONF_PLAY_MACRO_REQ_VALUES, ?CONF_PLAY_MACRO_REQ_TYPES);
 play_macro_req_v(JObj) -> play_macro_req_v(kz_json:to_proplist(JObj)).
+
+%%------------------------------------------------------------------------------
+%% @doc Takes {@link kz_term:proplist()}, creates JSON string or error.
+%% @end
+%%------------------------------------------------------------------------------
+-spec dtmf(kz_term:api_terms()) -> {'ok', iolist()} | {'error', string()}.
+dtmf(Prop) when is_list(Prop) ->
+    case dtmf_v(Prop) of
+        'true' -> kz_api:build_message(Prop, ?DTMF_HEADERS, ?OPTIONAL_DTMF_HEADERS);
+        'false' -> {'error', "Proplist failed validation for dtmf"}
+    end;
+dtmf(JObj) -> dtmf(kz_json:to_proplist(JObj)).
+
+-spec dtmf_v(kz_term:api_terms()) -> boolean().
+dtmf_v(Prop) when is_list(Prop) ->
+    kz_api:validate(Prop, ?DTMF_HEADERS, ?DTMF_VALUES, ?DTMF_TYPES);
+dtmf_v(JObj) -> dtmf_v(kz_json:to_proplist(JObj)).
+
+-spec is_valid_dtmf(binary() | number()) -> boolean().
+is_valid_dtmf(Digits) when is_binary(Digits) ->
+    case re:replace(Digits, "[^a-dA-D0-9*#]", "", [global, {return, binary}]) of
+        <<>> -> 'false';
+        _DTMF -> 'true'
+    end;
+is_valid_dtmf(Digits) when is_number(Digits) -> is_valid_dtmf(kz_term:to_binary(Digits));
+is_valid_dtmf(_) -> 'false'.
 
 %%------------------------------------------------------------------------------
 %% @doc Takes {@link kz_term:proplist()}, creates JSON string or error.

--- a/core/kazoo_call/src/kapps_conference_command.erl
+++ b/core/kazoo_call/src/kapps_conference_command.erl
@@ -1,7 +1,8 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2012-2022, 2600Hz
+%%% @copyright (C) 2012-2026, 2600Hz
 %%% @doc
 %%% @author Karl Anderson
+%%% @author Ruel Tmeizeh for Umojo, Inc.
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kapps_conference_command).
@@ -17,6 +18,7 @@
 -export([prompt/2, prompt/3]).
 -export([play_command/1, play_command/2]).
 -export([play/2, play/3]).
+-export([dtmf/2, dtmf/3]).
 -export([record/1, recordstop/1]).
 -export([relate_participants/3, relate_participants/4]).
 -export([stop_play/1, stop_play/2, stop_play/3]).
@@ -129,7 +131,6 @@ get_media_prompt(Media, Conference) ->
     Call = kapps_conference:call(Conference),
     kapps_call:get_prompt(Call, Media).
 
-
 -spec play_command(kz_term:ne_binary()) -> kz_term:proplist().
 play_command(Media) ->
     play_command(Media, 'undefined').
@@ -141,7 +142,6 @@ play_command(Media, ParticipantId) ->
     ,{<<"Participant-ID">>, ParticipantId}
     ].
 
-
 -spec play(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
 play(Media, Conference) ->
     play(Media, 'undefined', Conference).
@@ -149,6 +149,22 @@ play(Media, Conference) ->
 -spec play(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
 play(Media, ParticipantId, Conference) ->
     Command = play_command(Media, ParticipantId),
+    send_command(Command, Conference).
+
+-spec dtmf_command(kz_term:ne_binary(), non_neg_integer() | 'undefined') -> kz_term:proplist().
+dtmf_command(Digits, ParticipantId) ->
+    [{<<"Application-Name">>, <<"dtmf">>}
+    ,{<<"Digits">>, Digits}
+    ,{<<"Participant-ID">>, ParticipantId}
+    ].
+
+-spec dtmf(kz_term:ne_binary(), kapps_conference:conference()) -> 'ok'.
+dtmf(Digits, Conference) ->
+    dtmf(Digits, 'undefined', Conference).
+
+-spec dtmf(kz_term:ne_binary(), non_neg_integer() | 'undefined', kapps_conference:conference()) -> 'ok'.
+dtmf(Digits, ParticipantId, Conference) ->
+    Command = dtmf_command(Digits, ParticipantId),
     send_command(Command, Conference).
 
 -spec record(kapps_conference:conference()) -> 'ok'.


### PR DESCRIPTION
This PR adds the dialplan equivalent of `send_dtmf` to conferences, allowing an API call to trigger DTMF being sent to one or more conference participants.

- core/kazoo_call: add conference DTMF command
- core/kazoo_amqp: add AMQP conference DTMF command handling and validation
- applications/ecallmanager: add conference DTMF command support
- applications/crossbar: conference API modified to add DTMF sending to conference participant[s]


