### PR TITLE
core/kazoo_data: add notification upon attachment saved

### DIFF
--- a/applications/crossbar/priv/api/swagger.json
+++ b/applications/crossbar/priv/api/swagger.json
@@ -17306,6 +17306,115 @@
             ],
             "type": "object"
         },
+        "kapi.notifications.attachment_saved": {
+            "description": "AMQP API for notifications.attachment_saved",
+            "properties": {
+                "Account-DB": {
+                    "type": "string"
+                },
+                "Account-ID": {
+                    "type": "string"
+                },
+                "Attachment-URL": {
+                    "type": "string"
+                },
+                "Bcc": {
+                    "type": "string"
+                },
+                "CDR-ID": {
+                    "type": "string"
+                },
+                "Call-ID": {
+                    "type": "string"
+                },
+                "Caller-ID-Name": {
+                    "type": "string"
+                },
+                "Caller-ID-Number": {
+                    "type": "string"
+                },
+                "Cc": {
+                    "type": "string"
+                },
+                "Doc": {
+                    "type": "object"
+                },
+                "Duration": {
+                    "type": "integer"
+                },
+                "Event-Category": {
+                    "enum": [
+                        "notification"
+                    ],
+                    "type": "string"
+                },
+                "Event-Name": {
+                    "enum": [
+                        "attachment_saved"
+                    ],
+                    "type": "string"
+                },
+                "From": {
+                    "type": "string"
+                },
+                "From-Realm": {
+                    "type": "string"
+                },
+                "From-User": {
+                    "type": "string"
+                },
+                "HTML": {
+                    "type": "string"
+                },
+                "ID": {
+                    "type": "string"
+                },
+                "Name": {
+                    "type": "string"
+                },
+                "Owner-ID": {
+                    "type": "string"
+                },
+                "Preview": {
+                    "type": "string"
+                },
+                "Reply-To": {
+                    "type": "string"
+                },
+                "Storage-Type": {
+                    "type": "string"
+                },
+                "Subject": {
+                    "type": "string"
+                },
+                "Text": {
+                    "type": "string"
+                },
+                "Timestamp": {
+                    "type": "integer"
+                },
+                "To": {
+                    "type": "string"
+                },
+                "To-Realm": {
+                    "type": "string"
+                },
+                "To-User": {
+                    "type": "string"
+                },
+                "Type": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Account-DB",
+                "Account-ID",
+                "Doc",
+                "ID",
+                "Type"
+            ],
+            "type": "object"
+        },
         "kapi.notifications.bill_reminder": {
             "description": "AMQP API for notifications.bill_reminder",
             "properties": {

--- a/applications/crossbar/priv/couchdb/schemas/kapi.notifications.attachment_saved.json
+++ b/applications/crossbar/priv/couchdb/schemas/kapi.notifications.attachment_saved.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "_id": "kapi.notifications.attachment_saved",
+    "description": "AMQP API for notifications.attachment_saved",
+    "properties": {
+        "Account-DB": {
+            "type": "string"
+        },
+        "Account-ID": {
+            "type": "string"
+        },
+        "Attachment-URL": {
+            "type": "string"
+        },
+        "Bcc": {
+            "type": "string"
+        },
+        "CDR-ID": {
+            "type": "string"
+        },
+        "Call-ID": {
+            "type": "string"
+        },
+        "Caller-ID-Name": {
+            "type": "string"
+        },
+        "Caller-ID-Number": {
+            "type": "string"
+        },
+        "Cc": {
+            "type": "string"
+        },
+        "Doc": {
+            "type": "object"
+        },
+        "Duration": {
+            "type": "integer"
+        },
+        "Event-Category": {
+            "enum": [
+                "notification"
+            ],
+            "type": "string"
+        },
+        "Event-Name": {
+            "enum": [
+                "attachment_saved"
+            ],
+            "type": "string"
+        },
+        "From": {
+            "type": "string"
+        },
+        "From-Realm": {
+            "type": "string"
+        },
+        "From-User": {
+            "type": "string"
+        },
+        "HTML": {
+            "type": "string"
+        },
+        "ID": {
+            "type": "string"
+        },
+        "Name": {
+            "type": "string"
+        },
+        "Owner-ID": {
+            "type": "string"
+        },
+        "Preview": {
+            "type": "string"
+        },
+        "Reply-To": {
+            "type": "string"
+        },
+        "Storage-Type": {
+            "type": "string"
+        },
+        "Subject": {
+            "type": "string"
+        },
+        "Text": {
+            "type": "string"
+        },
+        "Timestamp": {
+            "type": "integer"
+        },
+        "To": {
+            "type": "string"
+        },
+        "To-Realm": {
+            "type": "string"
+        },
+        "To-User": {
+            "type": "string"
+        },
+        "Type": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "Account-DB",
+        "Account-ID",
+        "Doc",
+        "ID",
+        "Type"
+    ],
+    "type": "object"
+}

--- a/core/kazoo_amqp/src/api/kapi_notifications.erl
+++ b/core/kazoo_amqp/src/api/kapi_notifications.erl
@@ -1,9 +1,10 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc Notification messages, like voicemail left.
 %%% @author James Aimonetti
 %%% @author Karl Anderson
 %%% @author Hesaam Farhang
+%%% @author Ruel Tmeizeh
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kapi_notifications).
@@ -66,6 +67,9 @@
         ,voicemail_new/1, voicemail_new_v/1
         ,voicemail_saved/1, voicemail_saved_v/1
         ,voicemail_deleted/1, voicemail_deleted_v/1
+
+         %% Attachment notifications
+        ,attachment_saved/1, attachment_saved_v/1
 
          %% Webhook notifications
         ,webhook/1, webhook_v/1
@@ -131,6 +135,9 @@
         ,publish_voicemail_new/1, publish_voicemail_new/2
         ,publish_voicemail_saved/1, publish_voicemail_saved/2
         ,publish_voicemail_deleted/1, publish_voicemail_deleted/2
+
+         %% Attachment notifications
+        ,publish_attachment_saved/1
 
          %% Webhook notifications
         ,publish_webhook/1, publish_webhook/2
@@ -1247,6 +1254,46 @@ voicemail_deleted_definition() ->
                     ,required_headers = ?VOICEMAIL_DELETED_HEADERS
                     ,optional_headers = ?OPTIONAL_VOICEMAIL_DELETED_HEADERS
                     ,values = ?NOTIFY_VALUES(<<"voicemail_deleted">>)
+                    ,types = []
+                    }.
+
+%%%=============================================================================
+%%% Attachment Notifications Definitions
+%%%=============================================================================
+-define(ATTACHMENT_HEADERS, [<<"Account-DB">>
+                            ,<<"Account-ID">>
+                            ,<<"Doc">>
+                            ,<<"ID">>
+                            ,<<"Type">>
+                            ]).
+-define(OPTIONAL_ATTACHMENT_HEADERS, [<<"Call-ID">>
+                                     ,<<"Caller-ID-Name">>
+                                     ,<<"Caller-ID-Number">>
+                                     ,<<"CDR-ID">>
+                                     ,<<"Duration">>
+                                     ,<<"Name">>
+                                     ,<<"Owner-ID">>
+                                     ,<<"Storage-Type">>
+                                     ,<<"Timestamp">>
+                                          | ?DEFAULT_OPTIONAL_HEADERS
+                                     ]).
+%%------------------------------------------------------------------------------
+%% @doc Get Attachment Saved Notification API definition.
+%% @end
+%%------------------------------------------------------------------------------
+-spec attachment_saved_definition() -> kapi_definition:api().
+attachment_saved_definition() ->
+    #kapi_definition{name = <<"attachment_saved">>
+                    ,friendly_name = <<"Attachment Saved">>
+                    ,description = <<"This event is triggered any time an attachment is saved">>
+                    ,build_fun = fun attachment_saved/1
+                    ,validate_fun = fun attachment_saved_v/1
+                    ,publish_fun = fun publish_attachment_saved/1
+                    ,binding = ?BINDING_STRING(<<"attachment">>, <<"saved">>)
+                    ,restrict_to = 'attachment_saved'
+                    ,required_headers = ?ATTACHMENT_HEADERS
+                    ,optional_headers = ?OPTIONAL_ATTACHMENT_HEADERS
+                    ,values = ?NOTIFY_VALUES(<<"attachment_saved">>)
                     ,types = []
                     }.
 
@@ -2620,6 +2667,34 @@ publish_voicemail_deleted(API, ContentType) ->
                     ,values = Values
                     } = voicemail_deleted_definition(),
     {'ok', Payload} = kz_api:prepare_api_payload(API, Values, fun voicemail_deleted/1),
+    kz_amqp_util:notifications_publish(Binding, Payload, ContentType).
+
+%%%=============================================================================
+%%% Attachment Notifications Functions
+%%%=============================================================================
+
+%%------------------------------------------------------------------------------
+%% @doc Takes prop-list, creates JSON string and publish it on AMQP.
+%% @end
+%%------------------------------------------------------------------------------
+-spec attachment_saved(kz_term:api_terms()) -> api_formatter_return().
+attachment_saved(Prop) ->
+    build_message(Prop, attachment_saved_definition()).
+
+-spec attachment_saved_v(kz_term:api_terms()) -> boolean().
+attachment_saved_v(Prop) ->
+    validate(Prop, attachment_saved_definition()).
+
+-spec publish_attachment_saved(kz_term:api_terms()) -> 'ok'.
+publish_attachment_saved(JObj) ->
+    publish_attachment_saved(JObj, ?DEFAULT_CONTENT_TYPE).
+
+-spec publish_attachment_saved(kz_term:api_terms(), kz_term:ne_binary()) -> 'ok'.
+publish_attachment_saved(API, ContentType) ->
+    #kapi_definition{binding = Binding
+                    ,values = Values
+                    } = attachment_saved_definition(),
+    {'ok', Payload} = kz_api:prepare_api_payload(API, Values, fun attachment_saved/1),
     kz_amqp_util:notifications_publish(Binding, Payload, ContentType).
 
 %%%=============================================================================

--- a/core/kazoo_data/src/kzs_attachments.erl
+++ b/core/kazoo_data/src/kzs_attachments.erl
@@ -1,6 +1,8 @@
 %%%-----------------------------------------------------------------------------
-%%% @copyright (C) 2011-2022, 2600Hz
+%%% @copyright (C) 2011-2026, 2600Hz
 %%% @doc data adapter behaviour
+%%% @author 2600Hz
+%%% @author Ruel Tmeizeh
 %%% @end
 %%%-----------------------------------------------------------------------------
 -module(kzs_attachments).
@@ -178,7 +180,7 @@ attachment_handler_jobj(Handler, Props) ->
     kz_json:set_value(kz_term:to_binary(Handler), JObj, kz_json:new()).
 
 -spec handle_put_attachment(att_map(), kz_json:object(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary(), kz_term:ne_binary()
-                           , kz_term:proplist(), kz_term:proplist()) ->
+                           ,kz_term:proplist(), kz_term:proplist()) ->
           {'ok', kz_json:object()} |
           {'ok', kz_json:object(), kz_term:proplist()} |
           data_error().
@@ -187,7 +189,12 @@ handle_put_attachment(#{att_post_handler := 'stub'
                        ,server := {App, Conn}
                        }, _Att, DbName, DocId, AName, Contents, Options, _Props) ->
     kzs_cache:flush_cache_doc(DbName, DocId),
-    App:put_attachment(Conn, DbName, DocId, AName, Contents, Options);
+    case App:put_attachment(Conn, DbName, DocId, AName, Contents, Options) of
+        {'ok', Doc} ->
+            _ = publish_attachment_saved(Doc),
+            {'ok', Doc};
+        Error -> Error
+    end;
 
 handle_put_attachment(#{att_post_handler := 'external'}=Map, Att, DbName, DocId, _AName, _Contents, _Options, Props) ->
     case kzs_doc:open_doc(Map, DbName, DocId, []) of
@@ -201,7 +208,9 @@ handle_put_attachment(#{att_post_handler := 'external'}=Map, Att, DbName, DocId,
 external_attachment(Map, DbName, JObj, Att, Props) ->
     Atts = kz_json:merge_jobjs(Att, kz_json:get_value(?KEY_STUB_ATTACHMENTS, JObj, kz_json:new())),
     case kzs_doc:save_doc(Map, DbName, kz_json:set_values([{?KEY_STUB_ATTACHMENTS, Atts}], JObj), []) of
-        {'ok', Doc} -> {'ok', Doc, Props};
+        {'ok', Doc} ->
+            _ = publish_attachment_saved(Doc),
+            {'ok', Doc, Props};
         Error -> Error
     end.
 
@@ -263,4 +272,54 @@ handle_attachment_handler_error({'error', Reason, ExtendedError}, Options) ->
             {'error', Reason};
         'verbose' ->
             {'error', Reason, ExtendedError}
+    end.
+
+%%------------------------------------------------------------------------------
+%% @doc Publishes `attachment_saved' notification.
+%% @end
+%%------------------------------------------------------------------------------
+-spec publish_attachment_saved(kz_json:object()) -> kz_amqp_worker:request_return().
+publish_attachment_saved(JObj) ->
+    AccountDb = kz_json:get_ne_binary_value(<<"pvt_account_db">>, JObj),
+    ID = kz_json:get_ne_binary_value(<<"_id">>, JObj),
+    Attachments = kz_json:get_ne_json_value(<<"pvt_attachments">>, JObj, kz_json:new()),
+    FileName =
+        case kz_json:get_ne_binary_value(<<"name">>, JObj) of
+            'undefined' -> case kz_json:get_keys(Attachments) of %% sometimes 'name' isn't present
+                               [A1|_] -> A1;
+                               _ ->
+                                   lager:notice("could not determine attachment filename"),
+                                   <<"">>
+                           end;
+            Name -> Name
+        end,
+    Handler = kz_json:get_ne_json_value([<<"pvt_attachments">>, FileName, <<"handler">>], JObj, kz_json:new()),
+    StorageType =
+        case kz_json:get_keys(Handler) of
+            [H|_] -> H;
+            _ -> <<"native">>
+        end,
+
+    Props =
+        props:filter_undefined([{<<"Account-DB">>, AccountDb}
+                               ,{<<"Account-ID">>, kz_json:get_ne_binary_value(<<"pvt_account_id">>, JObj)}
+                               ,{<<"Call-ID">>, kz_json:get_ne_binary_value(<<"call_id">>, JObj)}
+                               ,{<<"Caller-ID-Name">>, kz_json:get_ne_binary_value(<<"caller_id_name">>, JObj)}
+                               ,{<<"Caller-ID-Number">>, kz_json:get_ne_binary_value(<<"caller_id_number">>, JObj)}
+                               ,{<<"CDR-ID">>, kz_json:get_ne_binary_value(<<"cdr_id">>, JObj)}
+                               ,{<<"Doc">>, JObj}
+                               ,{<<"Duration">>, kz_json:get_ne_integer_value(<<"duration">>, JObj)}
+                               ,{<<"ID">>, ID}
+                               ,{<<"Name">>, FileName}
+                               ,{<<"Owner-ID">>, kz_json:get_ne_binary_value([<<"custom_channel_vars">>, <<"Owner-ID">>], JObj)}
+                               ,{<<"Storage-Type">>, StorageType}
+                               ,{<<"Timestamp">>, kz_json:get_integer_value(<<"pvt_created">>, JObj)}
+                               ,{<<"Type">>, kz_json:get_ne_binary_value(<<"pvt_type">>, JObj)}
+                                | kz_api:default_headers(?APP_NAME, ?APP_VERSION)
+                               ]
+                              ),
+
+    case kz_amqp_worker:cast(Props, fun kapi_notifications:publish_attachment_saved/1) of
+        'ok' -> lager:debug("published attachment_saved for ~s/~s/~s", [AccountDb, ID, FileName]);
+        _Err -> lager:notice("error publishing attachment_saved for ~s/~s/~s ~p", [AccountDb, ID, FileName, _Err])
     end.


### PR DESCRIPTION
When an attachment is saved, this code will cause an AMQP notification to be published. The details of the saved item are included in the notification. This notification is needed when some process needs to act on a saved attachment immediately after it has been stored (i.e. an external service that transcribes a recording).